### PR TITLE
fix(devtools): don't collide with the default runtime function

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -163,7 +163,7 @@
                 }
               ],
               "optimization": true,
-              "outputHashing": "all",
+              "outputHashing": "none",
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
@@ -175,11 +175,6 @@
                   "type": "initial",
                   "maximumWarning": "2mb",
                   "maximumError": "5mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
                 }
               ]
             }

--- a/projects/shell-chrome/browserslist
+++ b/projects/shell-chrome/browserslist
@@ -5,8 +5,5 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
-Firefox ESR
-not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+last 2 chrome version
+last 2 firefox version

--- a/projects/shell-chrome/shell-chrome-webpack.config.js
+++ b/projects/shell-chrome/shell-chrome-webpack.config.js
@@ -4,5 +4,8 @@ module.exports = {
     background: 'projects/shell-chrome/src/app/background.ts',
     backend: 'projects/shell-chrome/src/app/backend.ts',
     devtools: 'projects/shell-chrome/src/devtools.ts',
+  },
+  output: {
+    jsonpFunction: '___ngDevToolsRuntime'
   }
 };

--- a/projects/shell-chrome/src/panel-devtools.ts
+++ b/projects/shell-chrome/src/panel-devtools.ts
@@ -1,7 +1,7 @@
 let reloadFns: ((url: string) => void)[] = [];
 export const panelDevTools = {
   injectBackend(cb?: () => void) {
-    injectScripts(['backend.js'], cb);
+    injectScripts(['backend.js', 'runtime.js'], cb);
   },
 
   onReload(reloadFn: (url: string) => void) {


### PR DESCRIPTION
Currently, we don't inject `runtime.js` because we collide with the `runtime.js` of the host Angular application. This creates problems with non-Angular apps which don't use the same app bundling and the `backend.js` does not execute. This PR renames the runtime function to `___ngDevToolsRuntime`, which fixes the issue.

Additionally, since we support only Chrome this PR also drops differential bundling. We support the last two major versions of Chrome (look at `browserlist`), but if users require, we can easily extend the set of supported browsers.

Lastly, to have predictable file names, this PR also drops the hash suffix in the `shell-chrome` project.