### PR TITLE
test: Add testing for devtools tabs and directive explorer components

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -12,12 +12,16 @@ export class DevToolsTabsComponent {
   @Input() messageBus: MessageBus<Events>;
   @Input() angularVersion: string | undefined = undefined;
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
-  @ViewChild(DirectiveExplorerComponent) componentExplorer: DirectiveExplorerComponent;
+  @ViewChild(DirectiveExplorerComponent) directiveExplorer: DirectiveExplorerComponent;
 
   inspectorRunning = false;
 
   toggleInspector(): void {
-    this.inspectorRunning = !this.inspectorRunning;
+    this.toggleInspectorState();
+    this.emitInspectorEvent();
+  }
+
+  emitInspectorEvent(): void {
     if (this.inspectorRunning) {
       this.messageBus.emit('inspectorStart');
       this.tabGroup.selectedIndex = 0;
@@ -26,7 +30,11 @@ export class DevToolsTabsComponent {
     }
   }
 
+  toggleInspectorState(): void {
+    this.inspectorRunning = !this.inspectorRunning;
+  }
+
   refresh(): void {
-    this.componentExplorer.refresh();
+    this.directiveExplorer.refresh();
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.spec.ts
@@ -1,0 +1,42 @@
+import { DevToolsTabsComponent } from './devtools-tabs.component';
+import { TestBed } from '@angular/core/testing';
+
+
+describe('DevtoolsTabsComponent', () => {
+  let messageBusMock;
+  let comp: DevToolsTabsComponent;
+
+  beforeEach(() => {
+    comp = TestBed.createComponent(DevToolsTabsComponent).componentInstance;
+    messageBusMock = jasmine.createSpyObj('messageBus', ['on', 'once', 'emit', 'destroy']);
+  });
+
+  it('should create instance from class', () => {
+    expect(comp).toBeTruthy();
+  });
+
+  it('toggles inspector flag', () => {
+    expect(comp.inspectorRunning).toBe(false);
+    comp.toggleInspectorState();
+    expect(comp.inspectorRunning).toBe(true);
+    comp.toggleInspectorState();
+    expect(comp.inspectorRunning).toBe(false);
+  });
+
+  it('emits inspector event', () => {
+    comp.tabGroup = jasmine.createSpyObj('tabGroup', ['selectedIndex']);
+    comp.messageBus = messageBusMock;
+    comp.toggleInspector();
+    expect(comp.messageBus.emit).toHaveBeenCalledTimes(1);
+    expect(comp.messageBus.emit).toHaveBeenCalledWith('inspectorStart');
+    comp.toggleInspector();
+    expect(comp.messageBus.emit).toHaveBeenCalledTimes(2);
+    expect(comp.messageBus.emit).toHaveBeenCalledWith('inspectorEnd');
+  });
+
+  it('calls child refresh method', () => {
+    comp.directiveExplorer = jasmine.createSpyObj('directiveExplorer', ['refresh']);
+    comp.refresh();
+    expect(comp.directiveExplorer.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -1,0 +1,80 @@
+import { DirectiveExplorerComponent } from './directive-explorer.component';
+import { ComponentExplorerViewQuery } from 'protocol';
+import { IndexedNode } from './directive-forest/index-forest';
+import SpyObj = jasmine.SpyObj;
+import Spy = jasmine.Spy;
+import { TestBed } from '@angular/core/testing';
+
+describe('DirectiveExplorerComponent', () => {
+  let messageBusMock;
+  let comp: DirectiveExplorerComponent;
+
+  beforeEach(() => {
+    comp = TestBed.createComponent(DirectiveExplorerComponent).componentInstance;
+    messageBusMock = jasmine.createSpyObj('messageBus', ['on', 'once', 'emit', 'destroy']);
+    comp.messageBus = messageBusMock;
+  });
+
+  it('should create instance from class', () => {
+    expect(comp).toBeTruthy();
+  });
+
+  it('return value in item for name tracking', () => {
+    const item = { key: 'value' };
+    const value = comp.nameTracking(0, item);
+    expect(value).toBe(item.key);
+  });
+
+  it('subscribe to backend events', () => {
+    comp.subscribeToBackendEvents();
+    expect(comp.messageBus.on).toHaveBeenCalledTimes(2);
+    expect(comp.messageBus.on).toHaveBeenCalledWith('elementDirectivesProperties', jasmine.any(Function));
+    expect(comp.messageBus.on).toHaveBeenCalledWith('latestComponentExplorerView', jasmine.any(Function));
+  });
+
+  describe('refresh', () => {
+    it('should emit getLatestComponentExplorerView event on refresh', () => {
+      comp.refresh();
+      expect(comp.messageBus.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit getLatestComponentExplorerView event with null view query', () => {
+      comp.refresh();
+      const nullViewQuery: ComponentExplorerViewQuery = { selectedElement: null, expandedProperties: null };
+      expect(comp.messageBus.emit).toHaveBeenCalledWith('getLatestComponentExplorerView', [nullViewQuery]);
+    });
+
+    it('should emit getLatestComponentExplorerView event on refresh with view query no properties', () => {
+      const currentSelectedElement = jasmine.createSpyObj('currentSelectedElement', ['id', 'children'])
+      currentSelectedElement.id = [0];
+      currentSelectedElement.children = [];
+      comp.currentSelectedElement = currentSelectedElement;
+      comp.propertyViews = jasmine.createSpyObj('propertyViews', ['toArray']);
+      (comp.propertyViews.toArray as Spy).and.returnValue([]);
+      comp.refresh();
+      const viewQuery: ComponentExplorerViewQuery = { selectedElement: comp.currentSelectedElement.id, expandedProperties: {} };
+      expect(comp.messageBus.emit).toHaveBeenCalledWith('getLatestComponentExplorerView', [viewQuery]);
+    });
+  });
+
+  describe('node selection event', () => {
+    let nodeMock: SpyObj<IndexedNode>;
+
+    beforeEach(() => {
+      nodeMock = jasmine.createSpyObj('node', ['id', 'children']);
+    });
+
+    it('sets current selected element', () => {
+      comp.handleNodeSelection(nodeMock);
+      expect(comp.currentSelectedElement).toBe(nodeMock);
+    });
+
+    it('fires node selection events', () => {
+      nodeMock.id = [0];
+      comp.handleNodeSelection(nodeMock);
+      expect(comp.messageBus.emit).toHaveBeenCalledTimes(2);
+      expect(comp.messageBus.emit).toHaveBeenCalledWith('getElementDirectivesProperties', [nodeMock.id]);
+      expect(comp.messageBus.emit).toHaveBeenCalledWith('setSelectedComponent', [nodeMock.id]);
+    });
+  });
+});


### PR DESCRIPTION
*Note:* Split apart old `toggleInspector()` so that each method in devtools-tabs operates on a single level of abstraction, making each one easier to read and test.