### PR TITLE
feat(directive forest): create copy to clipboard button for properties view

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.css
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.css
@@ -33,6 +33,9 @@ ng-property-view {
   overflow: hidden;
   line-height: 25px;
   font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .property-wrapper .element-header {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
@@ -22,7 +22,18 @@
     </ng-template>
   </div>
   <div *ngFor="let data of directivesData | keyvalue; trackBy: nameTracking" class="explorer-panel">
-    <header>Properties of {{ data.key }}</header>
+    <header>
+      Properties of {{ data.key }}
+      <button mat-icon-button (click)="copyPropData(data.value.props)">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true"
+             focusable="false" width="1em" height="1em"
+             preserveAspectRatio="xMidYMid meet" viewBox="0 0 8 8">
+          <path
+            d="M3.5 0c-.28 0-.5.22-.5.5V1h-.75c-.14 0-.25.11-.25.25V2h3v-.75C5 1.11 4.89 1 4.75 1H4V.5c0-.28-.22-.5-.5-.5zM.25 1C.11 1 0 1.11 0 1.25v6.5c0 .14.11.25.25.25h6.5c.14 0 .25-.11.25-.25v-6.5C7 1.11 6.89 1 6.75 1H6v2H1V1H.25z"
+            fill="#626262"/>
+        </svg>
+      </button>
+    </header>
     <ng-property-view
       [entityID]="getEntityID(data.key)"
       [messageBus]="messageBus"

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.module.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.module.ts
@@ -8,10 +8,11 @@ import { FilterComponent } from './directive-forest/filter/filter.component';
 import { PropertyViewModule } from './property-view/property-view.module';
 import { MatTreeModule } from '@angular/material/tree';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [DirectiveExplorerComponent, DirectiveForestComponent, FilterComponent],
   exports: [DirectiveExplorerComponent],
-  imports: [MatTreeModule, MatIconModule, CommonModule, PropertyViewModule, MatButtonModule],
+  imports: [MatTreeModule, MatIconModule, CommonModule, PropertyViewModule, MatButtonModule, MatSnackBarModule],
 })
 export class DirectiveExplorerModule {}

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -8,10 +8,12 @@ describe('DirectiveExplorerComponent', () => {
   let messageBusMock;
   let comp: DirectiveExplorerComponent;
   let applicationOperationsSpy;
+  let snackBarSpy;
 
   beforeEach(() => {
-    applicationOperationsSpy = jasmine.createSpyObj('messageBus', ['viewSource']);
-    comp = new DirectiveExplorerComponent(applicationOperationsSpy);
+    applicationOperationsSpy = jasmine.createSpyObj('_appOperations', ['viewSource', 'selectDomElement']);
+    snackBarSpy = jasmine.createSpyObj('_snackBar', ['show']);
+    comp = new DirectiveExplorerComponent(applicationOperationsSpy, snackBarSpy);
     messageBusMock = jasmine.createSpyObj('messageBus', ['on', 'once', 'emit', 'destroy']);
     comp.messageBus = messageBusMock;
   });

--- a/projects/shell-chrome/src/app/chrome-window-extensions.ts
+++ b/projects/shell-chrome/src/app/chrome-window-extensions.ts
@@ -37,5 +37,5 @@ const chromeWindowExtensions = {
       return null;
     }
     return node.nativeElement;
-  }
+  },
 };


### PR DESCRIPTION
A small nice-to-have.

Limitation: Cannot copy nested properties.

Edit: Underestimated the scope of this feature. Putting it on hold to focus on main issues. Will tackle this one in my spare time. 