### PR TITLE
fix: initialization of non-supported applications

### DIFF
--- a/projects/ng-devtools-backend/src/lib/angular-check.ts
+++ b/projects/ng-devtools-backend/src/lib/angular-check.ts
@@ -1,0 +1,29 @@
+declare const ng: any;
+
+export const appIsAngularInDevMode = (): boolean => {
+  return appIsAngular() && appHasGlobalNgDebugObject();
+};
+
+export const appIsAngularInProdMode = (): boolean => {
+  return appIsAngular() && !appHasGlobalNgDebugObject();
+};
+
+export const appIsAngular = (): boolean => {
+  return !!getAngularVersion();
+};
+
+export const appIsSupportedAngularVersion = (): boolean => {
+  return appIsAngular() && +getAngularVersion().toString().split('.')[0] >= 9;
+};
+
+const appHasGlobalNgDebugObject = (): boolean => {
+  return typeof ng !== 'undefined';
+};
+
+export const getAngularVersion = (): string | null | boolean => {
+  const el = document.querySelector('[ng-version]');
+  if (!el) {
+    return false;
+  }
+  return el.getAttribute('ng-version');
+};

--- a/projects/ng-devtools-backend/src/lib/change-detection-tracker.ts
+++ b/projects/ng-devtools-backend/src/lib/change-detection-tracker.ts
@@ -1,5 +1,5 @@
 import { getDirectiveForest, ComponentTreeNode } from './component-tree';
-import { runOutsideAngular, componentMetadata, patchTemplate } from './utils';
+import { runOutsideAngular, patchTemplate } from './utils';
 
 let hookInitialized = false;
 

--- a/projects/ng-devtools/src/lib/devtools.component.html
+++ b/projects/ng-devtools/src/lib/devtools.component.html
@@ -1,7 +1,21 @@
 <ng-container *ngIf="angularExists === true; else errorOrLoad">
-  <div class="devtools-wrapper noselect" [@enterAnimation]>
-    <ng-devtools-tabs [messageBus]="messageBus" [angularVersion]="angularVersion"></ng-devtools-tabs>
-  </div>
+  <ng-container *ngIf="supportedVersion; else notSupported">
+    <div class="devtools-wrapper noselect" [@enterAnimation]>
+      <ng-devtools-tabs [messageBus]="messageBus" [angularVersion]="angularVersion"></ng-devtools-tabs>
+    </div>
+  </ng-container>
+  <ng-template #notSupported>
+    <ng-container *ngIf="prodMode; else versionTooLow">
+      <div>
+        Angular Devtools only supports dev mode.
+      </div>
+    </ng-container>
+    <ng-template #versionTooLow>
+      <div>
+        Angular Devtools only supports Angular versions 9 and above.
+      </div>
+    </ng-template>
+  </ng-template>
 </ng-container>
 <ng-template #errorOrLoad>
   <ng-container *ngIf="angularExists === false; else load">
@@ -11,8 +25,7 @@
   </ng-container>
   <ng-template #load>
     <div class="initializing" *ngIf="angularExists === null">
-      <div class="loading">
-      </div>
+      <div class="loading"></div>
     </div>
   </ng-template>
 </ng-template>

--- a/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/projects/ng-devtools/src/lib/devtools.component.ts
@@ -24,7 +24,8 @@ import { animate, style, transition, trigger } from '@angular/animations';
 })
 export class DevToolsComponent implements OnInit, OnDestroy {
   angularExists: boolean | null = null;
-  angularVersion: string | undefined = undefined;
+  angularVersion: string | boolean | undefined = undefined;
+  prodMode: boolean;
   @Input() messageBus: MessageBus<Events>;
 
   private _interval$ = interval(500).subscribe(() => this.messageBus.emit('queryNgAvailability'));
@@ -32,11 +33,20 @@ export class DevToolsComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     console.log('Initialized the devtools UI');
 
-    this.messageBus.once('ngAvailability', ({ version }) => {
+    this.messageBus.once('ngAvailability', ({ version, prodMode }) => {
       this.angularExists = !!version;
       this.angularVersion = version;
+      this.prodMode = prodMode;
       this._interval$.unsubscribe();
     });
+  }
+
+  majorAngularVersion(): number {
+    return +this.angularVersion.toString().split('.')[0];
+  }
+
+  get supportedVersion(): boolean {
+    return this.majorAngularVersion() >= 9 && !this.prodMode;
   }
 
   ngOnDestroy(): void {

--- a/projects/protocol/src/lib/messages.ts
+++ b/projects/protocol/src/lib/messages.ts
@@ -113,7 +113,7 @@ export interface Events {
   shutdown: () => void;
   syn: () => void;
   queryNgAvailability: () => void;
-  ngAvailability: (config: { version: string | undefined }) => void;
+  ngAvailability: (config: { version: string | undefined | boolean, prodMode: boolean }) => void;
 
   inspectorStart: () => void;
   inspectorEnd: () => void;


### PR DESCRIPTION
Issue: #39 

Preview In order: Non Angular app (Vue), Angular 8 app, Angular 9 production build app served locally, Angular 9 app served locally, Demo-App (For regression purposes)

![ng-check-demo](https://user-images.githubusercontent.com/39253660/73965406-1af08300-48e2-11ea-9f7c-ed41965c4294.gif)
