### PR TITLE
refactor(shell chrome): remove unnecessary calls to handshakeWithBackend and unused syn event

### DIFF
--- a/projects/protocol/src/lib/messages.ts
+++ b/projects/protocol/src/lib/messages.ts
@@ -111,7 +111,6 @@ export type AppRecord = ComponentRecord | AppStartChangeDetection | AppEndChange
 export interface Events {
   handshake: () => void;
   shutdown: () => void;
-  syn: () => void;
   queryNgAvailability: () => void;
   ngAvailability: (config: { version: string | undefined | boolean; prodMode: boolean }) => void;
 

--- a/projects/shell-chrome/src/app/backend.ts
+++ b/projects/shell-chrome/src/app/backend.ts
@@ -7,7 +7,6 @@ const messageBus = new SamePageMessageBus('angular-devtools-backend', 'angular-d
 let initialized = false;
 messageBus.on('handshake', () => {
   console.log('Received init');
-  messageBus.emit('syn');
   if (initialized) {
     return;
   }

--- a/projects/shell-chrome/src/app/content-script.ts
+++ b/projects/shell-chrome/src/app/content-script.ts
@@ -37,8 +37,6 @@ localMessageBus.onAny((topic, args) => {
   chromeMessageBus.emit(topic, args);
 });
 
-handshakeWithBackend();
-
 if (!backendInitialized) {
   const retry = () => {
     if (backendInitialized || backgroundDisconnected) {


### PR DESCRIPTION
As far as I can tell these are left overs from prototyping. Lmk if thats not the case.