### PR TITLE
refactor(message bus): remove console logging events

### DIFF
--- a/projects/shell-chrome/src/app/chrome-message-bus.ts
+++ b/projects/shell-chrome/src/app/chrome-message-bus.ts
@@ -22,7 +22,6 @@ export class ChromeMessageBus extends MessageBus<Events> {
 
   onAny(cb: AnyEventCallback<Events>): () => void {
     const listener = (msg: ChromeMessage<Events, keyof Events>): void => {
-      console.log('Received message', msg);
       cb(msg.topic, msg.args);
     };
     this._port.onMessage.addListener(listener);
@@ -35,7 +34,6 @@ export class ChromeMessageBus extends MessageBus<Events> {
 
   on<E extends keyof Events>(topic: E, cb: Events[E]): () => void {
     const listener = (msg: ChromeMessage<Events, keyof Events>): void => {
-      console.log('Received message', msg);
       if (msg.topic === topic) {
         cb.apply(null, msg.args);
       }
@@ -59,7 +57,6 @@ export class ChromeMessageBus extends MessageBus<Events> {
   }
 
   emit<E extends keyof Events>(topic: E, args?: Parameters<Events[E]>): void {
-    console.log('@@ Sending message', topic, args);
     if (this._disconnected) {
       return;
     }

--- a/projects/shell-chrome/src/app/content-script.ts
+++ b/projects/shell-chrome/src/app/content-script.ts
@@ -29,12 +29,10 @@ const handshakeWithBackend = (): void => {
 };
 
 chromeMessageBus.onAny((topic, args) => {
-  console.log('Forwarding message from background to backend', topic);
   localMessageBus.emit(topic, args);
 });
 
 localMessageBus.onAny((topic, args) => {
-  console.log('Forwarding message from backend to background', topic);
   backendInitialized = true;
   chromeMessageBus.emit(topic, args);
 });

--- a/projects/shell-chrome/src/app/same-page-message-bus.ts
+++ b/projects/shell-chrome/src/app/same-page-message-bus.ts
@@ -55,7 +55,6 @@ export class SamePageMessageBus extends MessageBus<Events> {
   }
 
   emit<E extends keyof Events>(topic: E, args?: Parameters<Events[E]>): void {
-    console.log('@@ Sending message', topic, args);
     window.postMessage(
       {
         source: this._source,

--- a/src/iframe-message-bus.ts
+++ b/src/iframe-message-bus.ts
@@ -55,7 +55,6 @@ export class IFrameMessageBus extends MessageBus<Events> {
   }
 
   emit<E extends keyof Events>(topic: E, args?: Parameters<Events[E]>): void {
-    console.log('@@ Sending message', topic, args);
     this._docWindow.postMessage(
       {
         source: this._source,


### PR DESCRIPTION
These were useful initially when we only had a few events. IMO they now cause more harm than good.

I believe it would be much easier for developers to individually log what specific events they want themselves while developing, rather than try to dig through all the noise that these catch-all console logs produce.