### PR TITLE
fix: unselect node if position in tree changes

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -24,7 +24,7 @@ describe('DirectiveExplorerComponent', () => {
 
   it('subscribe to backend events', () => {
     comp.subscribeToBackendEvents();
-    expect(comp.messageBus.on).toHaveBeenCalledTimes(4);
+    expect(comp.messageBus.on).toHaveBeenCalledTimes(5);
     expect(comp.messageBus.on).toHaveBeenCalledWith('elementDirectivesProperties', jasmine.any(Function));
     expect(comp.messageBus.on).toHaveBeenCalledWith('latestComponentExplorerView', jasmine.any(Function));
     expect(comp.messageBus.on).toHaveBeenCalledWith('highlightComponentInTreeFromElement', jasmine.any(Function));
@@ -44,7 +44,13 @@ describe('DirectiveExplorerComponent', () => {
     });
 
     it('should emit getLatestComponentExplorerView event on refresh with view query no properties', () => {
-      const currentSelectedElement = jasmine.createSpyObj('currentSelectedElement', ['position', 'children']);
+      const currentSelectedElement = {
+        element: null,
+        position: [],
+        children: [],
+        component: jasmine.createSpyObj('component', ['id']),
+        directives: [],
+      };
       currentSelectedElement.position = [0];
       currentSelectedElement.children = [];
       comp.currentSelectedElement = currentSelectedElement;
@@ -56,8 +62,13 @@ describe('DirectiveExplorerComponent', () => {
       comp.propertyTab = propertyTab as any;
       (comp.propertyViews.toArray as Spy).and.returnValue([]);
       comp.refresh();
+
       const viewQuery: ComponentExplorerViewQuery = {
-        selectedElement: comp.currentSelectedElement.position,
+        selectedElement: {
+          position: comp.currentSelectedElement.position,
+          componentId: comp.currentSelectedElement.component ? comp.currentSelectedElement.component.id : null,
+          directiveIds: comp.currentSelectedElement.directives.map(dir => dir.id),
+        },
         expandedProperties: {},
       };
       expect(comp.messageBus.emit).toHaveBeenCalledWith('getLatestComponentExplorerView', [viewQuery]);

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -94,6 +94,12 @@ export class DirectiveForestComponent {
     }, 0);
   }
 
+  clearSelectedNode(): void {
+    this.selectNode.emit(null);
+    this.selectedNode = null;
+    this.parents = [];
+  }
+
   populateParents(position: ElementPosition): void {
     this.parents = position.reduce((nodes: FlatNode[], index: number) => {
       let nodeId = [index];

--- a/projects/protocol/src/lib/messages.ts
+++ b/projects/protocol/src/lib/messages.ts
@@ -65,13 +65,20 @@ export interface ComponentExplorerViewProperties {
 }
 
 export interface ComponentExplorerViewQuery {
-  selectedElement: ElementPosition | null;
+  selectedElement: ComponentExplorerViewQuerySelectedComponentProperties | null;
   expandedProperties: ComponentExplorerViewProperties;
+}
+
+export interface ComponentExplorerViewQuerySelectedComponentProperties {
+  position: ElementPosition;
+  componentId: number;
+  directiveIds: number[];
 }
 
 export interface ComponentExplorerView {
   forest: DevToolsNode[];
   properties: DirectivesProperties;
+  sameNode?: boolean;
 }
 
 export enum DirectiveEventType {


### PR DESCRIPTION
If the node that was previously selected before CD is no longer the same (i.e. the position of the old node now points to a new node), unselect that node. 

Alternatively we could run an id search on the new tree with a dfs algorithm to see if the old node still exists and then reselect that node on the ui. Wanted to get inputs on that idea before implementing.