### PR TITLE
feat(breadcrumbs): add overflow-x auto to breadcrumbs tab

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.css
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.css
@@ -5,6 +5,12 @@
   position: fixed;
   width: 100%;
   height: 20px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.parent-nodes::-webkit-scrollbar {
+  display: none;
 }
 
 .btn-node {


### PR DESCRIPTION
Temporary solution until/if we decide to implement breadcrumbs in the way that chrome devtools does.