### PR TITLE
fix(component tree observer): check if node.children is undefined before trying to convert it into an array

### DIFF
--- a/projects/ng-devtools-backend/src/lib/observer/observer.ts
+++ b/projects/ng-devtools-backend/src/lib/observer/observer.ts
@@ -171,7 +171,7 @@ export class ComponentTreeObserver {
     if (component) {
       componentAccumulator.push(component);
     } else {
-      Array.from(node.children).forEach(child =>
+      Array.from(node.children || []).forEach(child =>
         this._getAllNestedComponentsWithinDomNode(child, componentAccumulator)
       );
     }
@@ -185,9 +185,10 @@ export class ComponentTreeObserver {
       directives = ng.getDirectives(node);
     } catch {}
 
-    Array.from(node.children).forEach(
+    Array.from(node.children || []).forEach(
       child => (directives = directives.concat(this._getAllNestedDirectivesWithinDomNode(child)))
     );
+
     return directives;
   }
 


### PR DESCRIPTION
Fixes case where at any step of recursion the `node` variable points to a text node. Found this bug while testing on https://www.angular.io.