### PR TITLE
fix(component tree observer): index new nodes before firing callbacks

### DIFF
--- a/projects/ng-devtools-backend/src/lib/observer/observer.ts
+++ b/projects/ng-devtools-backend/src/lib/observer/observer.ts
@@ -129,17 +129,18 @@ export class ComponentTreeObserver {
 
   private _onAddedNodesMutation(node: Node): void {
     const components = this._getAllNestedComponentsWithinDomNode(node);
+    const directives = this._getAllNestedDirectivesWithinDomNode(node);
+
+    if (components.length + directives.length > 0) {
+      this._tracker.index();
+    }
+
     if (components.length > 0) {
       components.forEach(component => this._onAddedComponent(component));
     }
 
-    const directives = this._getAllNestedDirectivesWithinDomNode(node);
-    if (directives.length) {
+    if (directives.length > 0) {
       directives.forEach(dir => this._onAddedDirective(dir));
-    }
-
-    if (components.length + directives.length > 0) {
-      this._tracker.index();
     }
   }
 


### PR DESCRIPTION
Index new nodes before firing callback to fix issue where some callbacks rely on the newly indexed nodes. Found this bug while testing on https://www.angular.io.