### PR TITLE
fix(explorer): distinguish between items with and without children

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/diffing/index.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/diffing/index.ts
@@ -39,6 +39,7 @@ export const diff = <T>(differ: DefaultIterableDiffer<T>, a: T[], b: T[]) => {
 
   // Now we can set the new items and remove the deleted ones.
   const newItems: T[] = [];
+  const removedItems: T[] = [];
   differ.forEachAddedItem(record => {
     if (record.currentIndex !== null && record.previousIndex === null) {
       a[record.currentIndex] = record.item;
@@ -51,6 +52,7 @@ export const diff = <T>(differ: DefaultIterableDiffer<T>, a: T[], b: T[]) => {
     if (record.currentIndex === null && !alreadySet[record.previousIndex]) {
       a[record.previousIndex] = null;
     }
+    removedItems.push(record.item);
   });
 
   for (let i = a.length - 1; i >= 0; i--) {
@@ -59,5 +61,5 @@ export const diff = <T>(differ: DefaultIterableDiffer<T>, a: T[], b: T[]) => {
     }
   }
 
-  return { newItems };
+  return { newItems, removedItems };
 };

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source.ts
@@ -22,9 +22,7 @@ export interface FlatNode {
 
 const expandable = (node: IndexedNode) => !!node.children && node.children.length > 0;
 
-const trackBy = (_: number, item: FlatNode) => {
-  return item.id;
-};
+const trackBy = (_: number, item: FlatNode) => `${item.id}#${item.expandable}`;
 
 const getId = (node: IndexedNode) => {
   let prefix = '';
@@ -92,10 +90,11 @@ export class ComponentDataSource extends DataSource<FlatNode> {
 
     this.data.forEach(i => (i.newItem = false));
 
-    const { newItems } = diff(this._differ, this.data, flattenedCollection);
+    const { newItems, removedItems } = diff(this._differ, this.data, flattenedCollection);
     this._treeControl.dataNodes = this.data;
     this._flattenedData.next(this.data);
 
+    removedItems.forEach(item => this._nodeToFlat.delete(item.original));
     newItems.forEach(i => (i.newItem = true));
 
     return newItems;


### PR DESCRIPTION
The big was caused by the diffing logic. We weren't updating the `router-outlet` because we were getting the same instance. Although that is true, there's a special case when the same instance now has children, which should cause rerender of the item (it's not expandable).

This PR also cleans up the cache we have, so we don't leak memory.