### PR TITLE
fix: get the lview from the instance context

### DIFF
--- a/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -9,7 +9,7 @@ import {
 } from 'protocol';
 import { DebuggingAPI } from './interfaces';
 import { IndexedNode } from './observer/identity-tracker';
-import { buildDirectiveTree, METADATA_PROPERTY_NAME } from './lview-transform';
+import { buildDirectiveTree, METADATA_PROPERTY_NAME, getLViewFromDirectiveInstance } from './lview-transform';
 
 const ngDebug = (window as any).ng;
 
@@ -62,8 +62,8 @@ export const getLatestComponentState = (query: ComponentExplorerViewQuery): Dire
 };
 
 export const buildDirectiveForest = (ngd: DebuggingAPI): ComponentTreeNode[] => {
-  const roots = Array.from(document.documentElement.querySelectorAll('[ng-version]')).map(
-    el => ngd.getComponent(el)[METADATA_PROPERTY_NAME]
+  const roots = Array.from(document.documentElement.querySelectorAll('[ng-version]')).map(el =>
+    getLViewFromDirectiveInstance(ngd.getComponent(el))
   );
   return Array.prototype.concat.apply([], roots.map(buildDirectiveTree));
 };

--- a/projects/ng-devtools-backend/src/lib/lview-transform.ts
+++ b/projects/ng-devtools-backend/src/lib/lview-transform.ts
@@ -6,12 +6,23 @@ const HEADER_OFFSET = 19;
 const TYPE = 1;
 const ELEMENT = 0;
 const LVIEW_TVIEW = 1;
-const COMPONENTS = 8;
 export const METADATA_PROPERTY_NAME = '__ngContext__';
 
-export function isLContainer(value: any): boolean {
+const isLContainer = (value: any): boolean => {
   return Array.isArray(value) && value[TYPE] === true;
-}
+};
+
+const isLView = (value: any): boolean => {
+  return Array.isArray(value) && typeof value[TYPE] === 'object';
+};
+
+export const getLViewFromDirectiveInstance = (dir: any) => {
+  const context = dir[METADATA_PROPERTY_NAME];
+  if (isLView(context)) {
+    return context;
+  }
+  return context.lView;
+};
 
 export const getDirectiveHostElement = (dir: any) => {
   const ctx = dir[METADATA_PROPERTY_NAME];

--- a/projects/ng-devtools-backend/src/lib/observer/observer.ts
+++ b/projects/ng-devtools-backend/src/lib/observer/observer.ts
@@ -2,7 +2,7 @@ import { ElementPosition, LifecycleProfile } from 'protocol';
 import { componentMetadata } from '../utils';
 import { IdentityTracker, IndexedNode } from './identity-tracker';
 import { DEV_TOOLS_HIGHLIGHT_NODE_ID } from '../highlighter';
-import { METADATA_PROPERTY_NAME, getDirectiveHostElement } from '../lview-transform';
+import { getLViewFromDirectiveInstance, getDirectiveHostElement } from '../lview-transform';
 
 export type CreationCallback = (
   componentOrDirective: any,
@@ -201,7 +201,7 @@ export class ComponentTreeObserver {
   }
 
   private _observeLifecycle(directive: any, isComponent: boolean): void {
-    const ctx = directive[METADATA_PROPERTY_NAME];
+    const ctx = getLViewFromDirectiveInstance(directive);
     const tview = ctx[1];
     hookTViewProperties.forEach(hook => {
       const current = tview[hook];


### PR DESCRIPTION
Angular internally mutates the `__ngContext__` after we invoke `ng.getComponent`, that's where the bug was coming from.