### PR TITLE
fix(explorer): make sure we don't access position of an undefined parent

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -119,12 +119,19 @@ export class DirectiveForestComponent {
 
   populateParents(position: ElementPosition): void {
     this.parents = position.reduce((nodes: FlatNode[], index: number) => {
-      let nodeId = [index];
+      let nodePosition = [index];
       if (nodes.length > 0) {
-        nodeId = nodes[nodes.length - 1].position.concat(index);
+        nodePosition = nodes[nodes.length - 1].position.concat(index);
       }
-      const selectedNode = this.dataSource.data.find(item => item.position.toString() === nodeId.toString());
-      nodes.push(selectedNode);
+      // It's possible selectedNode to be undefined
+      // In this case, we don't want to push it to the list
+      // of parent nodes. Instead, we want to report a warning.
+      const selectedNode = this.dataSource.data.find(item => item.position.toString() === nodePosition.toString());
+      if (selectedNode) {
+        nodes.push(selectedNode);
+      } else {
+        console.warn('Cant find node for position', nodePosition);
+      }
       return nodes;
     }, []);
   }


### PR DESCRIPTION
While testing today I hit a bug in this method, accessing `position` of undefined. The return type of `find` is `T | undefined`, so handling this case should fix the error. There will be slight inaccuracy in the UI, but it shouldn't be that problematic.