### PR TITLE
build: enable no-unused-variable lint check

### DIFF
--- a/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -1,6 +1,5 @@
 import {
   DirectivePosition,
-  DirectivesProperties,
   ElementPosition,
   Events,
   MessageBus,
@@ -11,13 +10,7 @@ import {
   ComponentExplorerViewQuery,
 } from 'protocol';
 import { onChangeDetection } from './change-detection-tracker';
-import {
-  ComponentTreeNode,
-  getDirectiveMetaData,
-  getLatestComponentState,
-  queryDirectiveForest,
-  updateState,
-} from './component-tree';
+import { ComponentTreeNode, getLatestComponentState, queryDirectiveForest, updateState } from './component-tree';
 import { start as startProfiling, stop as stopProfiling } from './observer';
 import { serializeDirectiveState } from './state-serializer/state-serializer';
 import { ComponentInspector, ComponentInspectorOptions } from './component-inspector/component-inspector';

--- a/projects/ng-devtools-backend/src/lib/observer/observer.ts
+++ b/projects/ng-devtools-backend/src/lib/observer/observer.ts
@@ -37,8 +37,6 @@ export type DestroyCallback = (
   position: ElementPosition
 ) => void;
 
-declare const ng: any;
-
 export interface Config {
   onCreate: CreationCallback;
   onDestroy: DestroyCallback;

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -3,7 +3,6 @@ import {
   MessageBus,
   Events,
   DevToolsNode,
-  DirectivesProperties,
   ComponentExplorerViewQuery,
   ComponentExplorerView,
   ElementPosition,

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.module.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.module.ts
@@ -11,7 +11,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { PropertyTabModule } from './property-tab/property-tab.module';
 import { AngularSplitModule } from 'angular-split';
 import { DirectiveForestModule } from './directive-forest/directive-forest.module';
-import { ElementPropertyResolver } from './property-resolver/element-property-resolver';
 
 @NgModule({
   declarations: [DirectiveExplorerComponent, DirectiveForestComponent, FilterComponent],

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -1,5 +1,5 @@
 import { DirectiveExplorerComponent } from './directive-explorer.component';
-import { ComponentExplorerViewQuery, PropertyQueryTypes } from 'protocol';
+import { PropertyQueryTypes } from 'protocol';
 import { IndexedNode } from './directive-forest/index-forest';
 import SpyObj = jasmine.SpyObj;
 import { ElementPropertyResolver } from './property-resolver/element-property-resolver';
@@ -51,11 +51,6 @@ describe('DirectiveExplorerComponent', () => {
       currentSelectedElement.position = [0];
       currentSelectedElement.children = [];
       comp.currentSelectedElement = currentSelectedElement;
-      const propertyTab = {
-        propertyTabBody: {
-          propertyViews: jasmine.createSpyObj('propertyTab', ['toArray']),
-        },
-      };
       comp.refresh();
       expect(comp.currentSelectedElement).toBeTruthy();
       expect(messageBusMock.emit).toHaveBeenCalledWith('getLatestComponentExplorerView', [undefined]);

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'ng-filter',

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/profiler.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/profiler.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChildren, QueryList, OnInit, OnDestroy } from '@angular/core';
+import { Component, ViewChildren, QueryList, OnInit, OnDestroy } from '@angular/core';
 import { RecordingModalComponent } from './recording/recording-modal/recording-modal.component';
 import { MessageBus, Events, ProfilerFrame } from 'protocol';
 import { FileApiService } from '../../../file-api-service';

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/record-formatter/record-formatter.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/record-formatter/record-formatter.spec.ts
@@ -1,6 +1,5 @@
-import { FlamegraphFormatter } from './flamegraph-formatter';
 import { ElementProfile, ProfilerFrame } from 'protocol';
-import { AppEntry, RecordFormatter, TimelineView } from './record-formatter';
+import { AppEntry, RecordFormatter } from './record-formatter';
 
 class MockFormatter extends RecordFormatter<any> {
   addFrame(nodes: any[], elements: ElementProfile[], prev?: any): void {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core';
 import { VisualizationMode } from '../timeline.component';
-import { TimelineView } from '../record-formatter/record-formatter';
 import { FlamegraphNode } from '../record-formatter/flamegraph-formatter';
 import { WebtreegraphNode } from '../record-formatter/webtreegraph-formatter';
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/timeline.component.spec.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/timeline.component.spec.ts
@@ -2,10 +2,9 @@ import { TimelineComponent } from './timeline.component';
 
 describe('TimelineComponent', () => {
   let comp: TimelineComponent;
-  const sanitizer = {};
 
   beforeEach(() => {
-    comp = new TimelineComponent(sanitizer as any);
+    comp = new TimelineComponent();
   });
 
   it('should calculate the framerate from passed duration', () => {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/timeline.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/profiler/recording/timeline/timeline.component.ts
@@ -3,7 +3,6 @@ import { ProfilerFrame } from 'protocol';
 import { FlamegraphFormatter, FlamegraphNode } from './record-formatter/flamegraph-formatter';
 import { AppEntry, TimelineView, GraphNode } from './record-formatter/record-formatter';
 import { WebtreegraphFormatter, WebtreegraphNode } from './record-formatter/webtreegraph-formatter';
-import { DomSanitizer } from '@angular/platform-browser';
 
 export enum VisualizationMode {
   FlameGraph,
@@ -43,8 +42,6 @@ export class TimelineComponent {
   cmpVisualizationModes = VisualizationMode;
   visualizationMode = VisualizationMode.FlameGraph;
   graphData: GraphNode<FlamegraphNode | WebtreegraphNode>[] = [];
-
-  constructor(private sanitizer: DomSanitizer) {}
 
   get formatter(): FlamegraphFormatter | WebtreegraphFormatter {
     return formatters[this.visualizationMode];

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
@@ -1,4 +1,4 @@
-import { Descriptor, DirectivePosition, Events, MessageBus, Properties, PropType } from 'protocol';
+import { Descriptor, DirectivePosition, Events, MessageBus, Properties } from 'protocol';
 import { CollectionViewer, DataSource, SelectionChange } from '@angular/cdk/collections';
 import { BehaviorSubject, merge, Observable, Subscription } from 'rxjs';
 import { MatTreeFlattener } from '@angular/material/tree';
@@ -102,7 +102,7 @@ export class PropertyDataSource extends DataSource<FlatNode> {
     this._onRequestingNestedProperties();
     this._messageBus.emit('getNestedProperties', [this._entityPosition, parentPath]);
 
-    this._messageBus.once('nestedProperties', (position: DirectivePosition, data: Properties, path: string[]) => {
+    this._messageBus.once('nestedProperties', (position: DirectivePosition, data: Properties, _path: string[]) => {
       node.prop.descriptor.value = data.props;
       this._treeControl.expand(node);
       const props = this._arrayify(data.props, node.prop);

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IndexedNode } from '../../directive-forest/index-forest';
-import { ElementPropertyResolver } from '../../property-resolver/element-property-resolver';
 
 @Component({
   templateUrl: './property-tab-body.component.html',
@@ -10,8 +9,6 @@ import { ElementPropertyResolver } from '../../property-resolver/element-propert
 export class PropertyTabBodyComponent {
   @Input() currentSelectedElement: IndexedNode | null;
   @Output() copyPropData = new EventEmitter<string>();
-
-  constructor(private _nestedProps: ElementPropertyResolver) {}
 
   getCurrentDirectives(): string[] | undefined {
     if (!this.currentSelectedElement) {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IndexedNode } from '../../directive-forest/index-forest';
 
 @Component({

--- a/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/projects/ng-devtools/src/lib/devtools.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MessageBus, Events } from 'protocol';
 import { interval } from 'rxjs';
 import { animate, style, transition, trigger } from '@angular/animations';

--- a/projects/shell-chrome/src/main.ts
+++ b/projects/shell-chrome/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode, NgModuleRef } from '@angular/core';
+import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';

--- a/src/app/devtools-app/devtools-app.component.ts
+++ b/src/app/devtools-app/devtools-app.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, ViewChild, ElementRef } from '@angular/core';
 import { IFrameMessageBus } from 'src/iframe-message-bus';
 import { MessageBus, Events } from 'protocol';
 

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,7 @@
     "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
     "no-var-requires": false,
+    "no-unused-variable": true,
     "object-literal-key-quotes": [true, "as-needed"],
     "object-literal-sort-keys": false,
     "ordered-imports": false,


### PR DESCRIPTION
Decided to use ts-lints `no-unused-variable` instead of the ts compilers `noUnusedLocals` because the ts compiler will consider violations as an error and fail to build. 

In my opinion having unused imports/variables should not slow down development time by throwing errors during compilation.

With `no-unused-variable` the developer can check at any time if they have any unused imports/variables (as is often the case after a refactor) by running `ng lint`.