### PR TITLE
test: use built in cypress timeout option to wait for DOM update

### DIFF
--- a/cypress/integration/item-tracking.e2e.js
+++ b/cypress/integration/item-tracking.e2e.js
@@ -26,8 +26,6 @@ describe('Tracking items from application to component tree', () => {
         });
       });
 
-    cy.wait(500);
-
-    cy.get('mat-tree').find('mat-tree-node:contains("app-todo[TooltipDirective]")').its('length').should('eq', 3);
+    cy.get('mat-tree mat-tree-node:contains("app-todo[TooltipDirective]")', { timeout: 500 }).should('have.length', 3);
   });
 });


### PR DESCRIPTION
Reference: https://docs.cypress.io/guides/core-concepts/retry-ability.html

>  If the assertion that follows the cy.get() command fails, then the cy.get() command will requery the application’s DOM again. Then Cypress will try the assertion against the elements yielded from cy.get(). If the assertion still fails, cy.get() will try requerying the DOM again, and so on until the cy.get() command timeout is reached.