### PR TITLE
feat: allow user to select function properties in chrome to view the function definition

### DIFF
--- a/projects/ng-devtools/src/lib/application-operations.ts
+++ b/projects/ng-devtools/src/lib/application-operations.ts
@@ -1,6 +1,7 @@
-import { ElementPosition } from 'protocol';
+import { DirectivePosition, ElementPosition } from 'protocol';
 
 export abstract class ApplicationOperations {
   abstract viewSource(position: ElementPosition): void;
   abstract selectDomElement(position: ElementPosition): void;
+  abstract inspectFunction(position: DirectivePosition, keyPath: string[]): void;
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
@@ -13,7 +13,11 @@
   </as-split-area>
   <as-split-area size="40" minSize="25">
     <div class="property-tab-wrapper">
-      <ng-property-tab [currentSelectedElement]="currentSelectedElement" (viewSource)="viewSource()"></ng-property-tab>
+      <ng-property-tab
+        [currentSelectedElement]="currentSelectedElement"
+        (inspectFunction)="inspectFunction($event)"
+        (viewSource)="viewSource()"
+      ></ng-property-tab>
     </div>
   </as-split-area>
 </as-split>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -8,6 +8,7 @@ import {
   ElementPosition,
   PropertyQuery,
   PropertyQueryTypes,
+  DirectivePosition,
 } from 'protocol';
 import { IndexedNode } from './directive-forest/index-forest';
 import { ApplicationOperations } from '../../application-operations';
@@ -15,7 +16,9 @@ import { Subject } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
 import { ElementPropertyResolver } from './property-resolver/element-property-resolver';
 import { FlatNode } from './directive-forest/component-data-source';
+import { FlatNode as PropertyFlatNode } from './property-resolver/element-property-resolver';
 import { DirectiveForestComponent } from './directive-forest/directive-forest.component';
+import { constructPathOfKeysToPropertyValue } from './property-resolver/directive-property-resolver';
 
 const sameDirectives = (a: IndexedNode, b: IndexedNode) => {
   if ((a.component && !b.component) || (!a.component && b.component)) {
@@ -185,5 +188,10 @@ export class DirectiveExplorerComponent implements OnInit {
   handleSetParents(parents: FlatNode[] | null): void {
     this.parents = parents;
     this._cdr.detectChanges();
+  }
+
+  inspectFunction({ node, directivePosition }: { node: PropertyFlatNode; directivePosition: DirectivePosition }): void {
+    const keyPath = constructPathOfKeysToPropertyValue(node.prop);
+    this._appOperations.inspectFunction(directivePosition, keyPath);
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
@@ -31,6 +31,15 @@ const getDirectiveControls = (
   };
 };
 
+export const constructPathOfKeysToPropertyValue = (nodePropToGetKeysFor: Property, keys: string[] = []): string[] => {
+  keys.unshift(nodePropToGetKeysFor.name);
+  const parentNodeProp = nodePropToGetKeysFor.parent;
+  if (parentNodeProp) {
+    constructPathOfKeysToPropertyValue(parentNodeProp, keys);
+  }
+  return keys;
+};
+
 export class DirectivePropertyResolver {
   _treeFlattener = new MatTreeFlattener(
     (node: Property, level: number): FlatNode => {
@@ -78,6 +87,10 @@ export class DirectivePropertyResolver {
     return this._props.props;
   }
 
+  get directivePosition(): DirectivePosition {
+    return this._directivePosition;
+  }
+
   getExpandedProperties(): NestedProp[] {
     return [
       ...getExpandedDirectiveProperties(this._inputsDataSource.data),
@@ -97,18 +110,9 @@ export class DirectivePropertyResolver {
 
   updateValue(node: FlatNode, newValue: any): void {
     const directiveId = this._directivePosition;
-    const keyPath = this._constructPathOfKeysToPropertyValue(node.prop);
+    const keyPath = constructPathOfKeysToPropertyValue(node.prop);
     this._messageBus.emit('updateState', [{ directiveId, keyPath, newValue }]);
     node.prop.descriptor.value = newValue;
-  }
-
-  private _constructPathOfKeysToPropertyValue(nodePropToGetKeysFor: Property, keys: string[] = []): string[] {
-    keys.unshift(nodePropToGetKeysFor.name);
-    const parentNodeProp = nodePropToGetKeysFor.parent;
-    if (parentNodeProp) {
-      this._constructPathOfKeysToPropertyValue(parentNodeProp, keys);
-    }
-    return keys;
   }
 
   private _getChildren(prop: Property): Property[] | undefined {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="currentSelectedElement">
   <div *ngFor="let directive of getCurrentDirectives()" class="explorer-panel">
-    <ng-property-view [directive]="directive"></ng-property-view>
+    <ng-property-view (inspectFunction)="inspectFunction.emit($event)" [directive]="directive"></ng-property-view>
   </div>
 </ng-container>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
@@ -1,5 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IndexedNode } from '../../directive-forest/index-forest';
+import { FlatNode } from '../../property-resolver/element-property-resolver';
+import { DirectivePosition } from 'protocol';
 
 @Component({
   templateUrl: './property-tab-body.component.html',
@@ -8,6 +10,7 @@ import { IndexedNode } from '../../directive-forest/index-forest';
 })
 export class PropertyTabBodyComponent {
   @Input() currentSelectedElement: IndexedNode | null;
+  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   getCurrentDirectives(): string[] | undefined {
     if (!this.currentSelectedElement) {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.html
@@ -10,6 +10,7 @@
         [dataSource]="panels[index].controls.dataSource"
         [treeControl]="panels[index].controls.treeControl"
         (updateValue)="updateValue($event)"
+        (inspectFunction)="handleInspectFunction($event)"
       ></ng-property-view-tree>
     </mat-expansion-panel>
   </div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {
   DirectivePropertyResolver,
   DirectiveTreeData,
 } from '../../../../property-resolver/directive-property-resolver';
 import { FlatNode } from '../../../../property-resolver/element-property-resolver';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { DirectivePosition } from 'protocol';
 
 @Component({
   selector: 'ng-property-view-body',
@@ -16,6 +17,8 @@ export class PropertyViewBodyComponent {
   @Input() directiveInputControls: DirectiveTreeData;
   @Input() directiveOutputControls: DirectiveTreeData;
   @Input() directiveStateControls: DirectiveTreeData;
+
+  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   categoryOrder = [0, 1, 2];
 
@@ -49,5 +52,12 @@ export class PropertyViewBodyComponent {
 
   drop(event: CdkDragDrop<any, any>): void {
     moveItemInArray(this.categoryOrder, event.previousIndex, event.currentIndex);
+  }
+
+  handleInspectFunction(node: FlatNode): void {
+    this.inspectFunction.emit({
+      node,
+      directivePosition: this.controller.directivePosition,
+    });
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
@@ -1,0 +1,3 @@
+<span class="value" [class.function]="isFunctionProp" (click)="isFunctionProp && inspectFunction.emit()">
+  {{ node.prop.descriptor.preview }}
+</span>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.scss
@@ -1,0 +1,7 @@
+.function {
+  &:hover {
+    background: #4da1ff;
+    color: #fff;
+    cursor: pointer;
+  }
+}

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.ts
@@ -1,0 +1,17 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { PropType } from 'protocol';
+import { FlatNode } from '../../../../../../property-resolver/element-property-resolver';
+
+@Component({
+  selector: 'ng-property-preview',
+  templateUrl: './property-preview.component.html',
+  styleUrls: ['./property-preview.component.scss'],
+})
+export class PropertyPreviewComponent {
+  @Input() node: FlatNode;
+  @Output() inspectFunction = new EventEmitter<void>();
+
+  get isFunctionProp(): boolean {
+    return this.node.prop.descriptor.type === PropType.Function;
+  }
+}

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.html
@@ -2,9 +2,7 @@
   <mat-tree-node matTreeNodePaddingIndent="14" *matTreeNodeDef="let node" matTreeNodePadding>
     <span class="name non-expandable"> {{ node.prop.name }} </span>:&nbsp;
     <ng-container *ngIf="!node.prop.descriptor.editable; else editable">
-      <span class="value">
-        {{ node.prop.descriptor.preview }}
-      </span>
+      <ng-property-preview (inspectFunction)="inspectFunction.emit(node)" [node]="node"></ng-property-preview>
     </ng-container>
     <ng-template #editable>
       <ng-property-editor

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.ts
@@ -12,6 +12,7 @@ export class PropertyViewTreeComponent {
   @Input() dataSource: PropertyDataSource;
   @Input() treeControl: FlatTreeControl<FlatNode>;
   @Output() updateValue = new EventEmitter<any>();
+  @Output() inspectFunction = new EventEmitter<any>();
 
   hasChild = (_: number, node: FlatNode): boolean => node.expandable;
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.html
@@ -4,4 +4,5 @@
   [directiveInputControls]="directiveInputControls"
   [directiveOutputControls]="directiveOutputControls"
   [directiveStateControls]="directiveStateControls"
+  (inspectFunction)="inspectFunction.emit($event)"
 ></ng-property-view-body>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { DirectivePropertyResolver, DirectiveTreeData } from '../../../property-resolver/directive-property-resolver';
-import { ElementPropertyResolver } from '../../../property-resolver/element-property-resolver';
+import { ElementPropertyResolver, FlatNode } from '../../../property-resolver/element-property-resolver';
+import { DirectivePosition } from 'protocol';
 
 @Component({
   selector: 'ng-property-view',
@@ -9,6 +10,7 @@ import { ElementPropertyResolver } from '../../../property-resolver/element-prop
 })
 export class PropertyViewComponent {
   @Input() directive: string;
+  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   constructor(private _nestedProps: ElementPropertyResolver) {}
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.module.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.module.ts
@@ -9,6 +9,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { PropertyEditorComponent } from './property-view-body/property-view-tree/property-editor/property-editor.component';
 import { FormsModule } from '@angular/forms';
+import { PropertyPreviewComponent } from './property-view-body/property-view-tree/property-preview/property-preview.component';
 
 @NgModule({
   declarations: [
@@ -17,6 +18,7 @@ import { FormsModule } from '@angular/forms';
     PropertyViewComponent,
     PropertyViewTreeComponent,
     PropertyEditorComponent,
+    PropertyPreviewComponent,
   ],
   imports: [MatTreeModule, CommonModule, MatExpansionModule, DragDropModule, FormsModule],
   exports: [PropertyViewBodyComponent, PropertyViewHeaderComponent, PropertyViewComponent],

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
@@ -1,3 +1,7 @@
 <ng-property-tab-header [currentSelectedElement]="currentSelectedElement" (viewSource)="viewSource.emit()">
 </ng-property-tab-header>
-<ng-property-tab-body [currentSelectedElement]="currentSelectedElement"> </ng-property-tab-body>
+<ng-property-tab-body
+  (inspectFunction)="inspectFunction.emit($event)"
+  [currentSelectedElement]="currentSelectedElement"
+>
+</ng-property-tab-body>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { IndexedNode } from '../directive-forest/index-forest';
 import { PropertyTabBodyComponent } from './property-tab-body/property-tab-body.component';
+import { FlatNode } from '../property-resolver/element-property-resolver';
+import { DirectivePosition } from 'protocol';
 
 @Component({
   templateUrl: './property-tab.component.html',
@@ -9,6 +11,7 @@ import { PropertyTabBodyComponent } from './property-tab-body/property-tab-body.
 export class PropertyTabComponent {
   @Input() currentSelectedElement: IndexedNode;
   @Output() viewSource = new EventEmitter<void>();
+  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   @ViewChild(PropertyTabBodyComponent) propertyTabBody: PropertyTabBodyComponent;
 }

--- a/projects/shell-chrome/src/app/chrome-application-operations.ts
+++ b/projects/shell-chrome/src/app/chrome-application-operations.ts
@@ -1,4 +1,4 @@
-import { ElementPosition } from 'protocol';
+import { DirectivePosition, ElementPosition } from 'protocol';
 import { ApplicationOperations } from 'ng-devtools';
 
 export class ChromeApplicationOperations extends ApplicationOperations {
@@ -8,9 +8,21 @@ export class ChromeApplicationOperations extends ApplicationOperations {
     }
   }
 
-  selectDomElement(position: number[]): void {
+  selectDomElement(position: ElementPosition): void {
     if (chrome.devtools) {
       chrome.devtools.inspectedWindow.eval(`inspect(inspectedApplication.findDomElementByPosition('${position}'))`);
+    }
+  }
+
+  inspectFunction(directivePosition: DirectivePosition, keyPath: string[]): void {
+    if (chrome.devtools) {
+      const args = {
+        directivePosition,
+        keyPath,
+      };
+      chrome.devtools.inspectedWindow.eval(
+        `inspect(inspectedApplication.findFunctionByPosition('${JSON.stringify(args)}'))`
+      );
     }
   }
 }

--- a/src/demo-application-operations.ts
+++ b/src/demo-application-operations.ts
@@ -1,12 +1,17 @@
 import { ApplicationOperations } from 'ng-devtools';
+import { DirectivePosition, ElementPosition } from 'protocol';
 
 export class DemoApplicationOperations extends ApplicationOperations {
-  viewSource(position: number[]): void {
+  viewSource(position: ElementPosition): void {
     console.warn('viewSource() is not implemented because the demo app runs in an Iframe');
     throw new Error('Not implemented in demo app.');
   }
-  selectDomElement(position: number[]): void {
+  selectDomElement(position: ElementPosition): void {
     console.warn('selectDomElement() is not implemented because the demo app runs in an Iframe');
     throw new Error('Not implemented in demo app.');
+  }
+  inspectFunction(position: DirectivePosition, keyPath: string[]): void {
+    console.warn('inspectFunction() is not implemented because the demo app runs in an Iframe');
+    return;
   }
 }


### PR DESCRIPTION
An iteration on the property view.

Users can now select properties that are functions to inspect them in the chrome devtools.

![inspect-function](https://user-images.githubusercontent.com/39253660/78075201-168c9780-7372-11ea-8b38-fb746b043e18.gif)
