### PR TITLE
perf: use WeakMap to reduce memory usage when memoizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clone-deep": "^4.0.1",
     "document-register-element": "^1.7.2",
     "file-saver": "^2.0.2",
-    "memo-decorator": "^1.0.2",
+    "memo-decorator": "^2.0.1",
     "ngx-flamegraph": "0.0.6",
     "pretty-quick": "^2.0.1",
     "rxjs": "~6.5.3",

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/bargraph-formatter/bargraph-formatter.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/bargraph-formatter/bargraph-formatter.ts
@@ -10,7 +10,8 @@ export interface BargraphNode {
 }
 
 export class BarGraphFormatter extends RecordFormatter<BargraphNode[]> {
-  @memo() formatFrame(frame: ProfilerFrame): BargraphNode[] {
+  @memo({ cache: new WeakMap() })
+  formatFrame(frame: ProfilerFrame): BargraphNode[] {
     const result: BargraphNode[] = [];
     this.addFrame(result, frame.directives);
     return result.filter((element) => element.value > 0).sort((a, b) => b.value - a.value);

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/flamegraph-formatter/flamegraph-formatter.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/flamegraph-formatter/flamegraph-formatter.ts
@@ -1,6 +1,5 @@
 import { RecordFormatter } from '../record-formatter';
 import { ElementProfile, ProfilerFrame } from 'protocol';
-import memo from 'memo-decorator';
 
 export interface FlamegraphNode {
   value: number;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/tree-map-formatter/tree-map-formatter.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/tree-map-formatter/tree-map-formatter.ts
@@ -11,7 +11,8 @@ export interface TreeMapNode {
 }
 
 export class TreeMapFormatter extends RecordFormatter<TreeMapNode> {
-  @memo() formatFrame(record: ProfilerFrame): TreeMapNode {
+  @memo({ cache: new WeakMap() })
+  formatFrame(record: ProfilerFrame): TreeMapNode {
     const children: TreeMapNode[] = [];
     this.addFrame(children, record.directives);
     const size = children.reduce((accum, curr) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6670,12 +6670,10 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memo-decorator@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/memo-decorator/-/memo-decorator-1.0.2.tgz#d687243b9bf873be6565936961d1a0b2722fff19"
-  integrity sha512-wIwrRH1NebSdDM46KCJNe8MgMjaukjrh3rYkVhoTh3LmC9r7miiT0wqwfBOWobmDd5LMc7DRirmqqPYK/EYspA==
-  dependencies:
-    lodash.memoize "^4.1.2"
+memo-decorator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/memo-decorator/-/memo-decorator-2.0.1.tgz#599db686337a53af3e2f59991f5f61b96e96c62b"
+  integrity sha512-Cydoauo7y1Uad1UuznJqhuEQCt6adIl1w5ik3WmNl4FJeBmWAaMs64qyGRahaXWK/Dlmt/+QNesRTeFUcpJPkQ==
 
 memory-fs@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This way we don't preserve the selected `ProfilerFrame` across recordings.