### PR TITLE
fix: reset the timeline component when discarding a recording

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
@@ -17,13 +17,8 @@
     <p class="recording" [class.hidden]="state !== 'recording'">
       <ng-recording-modal></ng-recording-modal>
     </p>
-    <p class="visualization" [class.hidden]="state !== 'visualizing'">
-      <ng-recording-timeline
-        [class.hidden]="state !== 'visualizing'"
-        [records]="stream"
-        (exportProfile)="exportProfilerResults()"
-      >
-      </ng-recording-timeline>
+    <p class="visualization" *ngIf="state === 'visualizing'">
+      <ng-recording-timeline [records]="stream" (exportProfile)="exportProfilerResults()"> </ng-recording-timeline>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This way we don't preserve the selected `ProfilerFrame` across recordings.