### PR TITLE
refactor: remove getComponent calls in places it is no longer needed

### DIFF
--- a/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -160,7 +160,7 @@ const findElementIDFromNativeElementInForest = (
   return null;
 };
 
-export const findNodeFromSerializedPosition = (serializedPosition: string) => {
+export const findNodeFromSerializedPosition = (serializedPosition: string): ComponentTreeNode | null => {
   const position: number[] = serializedPosition.split(',').map((index) => parseInt(index, 10));
   return queryDirectiveForest(position, buildDirectiveForest());
 };

--- a/projects/ng-devtools-backend/src/lib/selected-component.ts
+++ b/projects/ng-devtools-backend/src/lib/selected-component.ts
@@ -28,7 +28,7 @@ const _setConsoleReference = (referenceNode: ConsoleReferenceNode) => {
 };
 
 const prepareCurrentReferencesForInsertion = (referenceNode: ConsoleReferenceNode) => {
-  const foundIndex = nodesForConsoleReference.findIndex(nodeToLookFor =>
+  const foundIndex = nodesForConsoleReference.findIndex((nodeToLookFor) =>
     arrayEquals(nodeToLookFor.position, referenceNode.position)
   );
   if (foundIndex !== -1) {
@@ -44,13 +44,13 @@ const assignConsoleReferencesFrom = (referenceNodes: ConsoleReferenceNode[]) => 
   );
 };
 
-const setDirectiveKey = (node: ComponentTreeNode | null, key) => {
+const setDirectiveKey = (node: ComponentTreeNode | null, key: string) => {
   Object.defineProperty(window, key, {
     get: () => {
-      if (node && node.nativeElement instanceof HTMLElement) {
-        return ng.getComponent(node.nativeElement) || node;
+      if (node?.component) {
+        return node.component.instance;
       }
-      if (node) {
+      if (node?.nativeElement) {
         return node.nativeElement;
       }
       return node;

--- a/projects/shell-chrome/src/app/chrome-window-extensions.ts
+++ b/projects/shell-chrome/src/app/chrome-window-extensions.ts
@@ -23,9 +23,8 @@ const chromeWindowExtensions = {
       console.error(`Cannot find element associated with node ${serializedId}`);
       return;
     }
-    const root = node.nativeElement instanceof HTMLElement && ng.getComponent(node.nativeElement);
-    if (root) {
-      return root.constructor;
+    if (node.component) {
+      return node.component.instance.constructor;
     } else {
       console.error('This component has no instance and therefore no constructor');
     }


### PR DESCRIPTION
Noticed this change could be made while regression testing on production apps (was curious to see how much functionality worked in prod). The change is minimal for apps in dev mode, but it bypasses the need to use the ng debug object in these cases.  