### PR TITLE
fix: directive forest tree wrapper css

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -120,7 +120,6 @@
 }
 
 .tree-wrapper {
-  height: calc(100% - 50px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Before:
<img width="606" alt="Screen Shot 2020-04-02 at 8 15 12 PM" src="https://user-images.githubusercontent.com/39253660/78311505-0a920880-751f-11ea-9a9d-a01b71880ae1.png">

After:
<img width="608" alt="Screen Shot 2020-04-02 at 8 18 52 PM" src="https://user-images.githubusercontent.com/39253660/78311566-357c5c80-751f-11ea-809b-bcb6aeb40abb.png">
