### PR TITLE
refactor(timeline): remove render case that is no longer used

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
@@ -1,16 +1,11 @@
-<ng-container *ngIf="profilerFrames.length > 1; else resultsWithoutControls">
-  <ng-container *ngTemplateOutlet="recordView; context: { record: frame, showControls: true }"></ng-container>
+<ng-container *ngIf="profilerFrames.length > 0; else noRecords">
+  <ng-container *ngTemplateOutlet="recordView; context: { record: frame }"></ng-container>
 </ng-container>
-<ng-template #resultsWithoutControls>
-  <ng-container *ngIf="profilerFrames.length === 1; else noRecords">
-    <ng-container *ngTemplateOutlet="recordView; context: { record: profilerFrames[0] }"></ng-container>
-  </ng-container>
-  <ng-template #noRecords>
-    Nothing was profiled
-  </ng-template>
+<ng-template #noRecords>
+  Nothing was profiled
 </ng-template>
 
-<ng-template let-record="record" let-showControls="showControls" #recordView>
+<ng-template let-record="record" #recordView>
   <div class="controls">
     <button mat-stroked-button (click)="exportProfile.emit()">Export to JSON</button>
     <mat-form-field>


### PR DESCRIPTION
This case handled the scenario of profiling only one frame back when we still had the slider. The showControls variable is no longer needed.