### PR TITLE
test(item-tracking): let timeout config default to it's default value

### DIFF
--- a/cypress/integration/item-tracking.e2e.js
+++ b/cypress/integration/item-tracking.e2e.js
@@ -26,6 +26,6 @@ describe('Tracking items from application to component tree', () => {
         });
       });
 
-    cy.get('mat-tree mat-tree-node:contains("app-todo[TooltipDirective]")', { timeout: 200 }).should('have.length', 3);
+    cy.get('mat-tree mat-tree-node:contains("app-todo[TooltipDirective]")').should('have.length', 3);
   });
 });


### PR DESCRIPTION
Attempt 2 at fixing flakey failures in e2e tests.