### PR TITLE
feat: allow user to hide frames less than the mean duration

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.html
@@ -1,5 +1,3 @@
-<mat-checkbox (change)="updateView($event)" class="show-change-detection">Change detection</mat-checkbox>
-
 <div class="level-profile-wrapper" [class.split-width]="selectedEntry">
   <ngx-flamegraph
     (frameClick)="selectFrame($event)"

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.scss
@@ -91,9 +91,3 @@
 .txt-total-time {
   font-weight: bold;
 }
-
-.show-change-detection {
-  position: absolute;
-  top: 35px;
-  left: 347px;
-}

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
@@ -20,6 +20,10 @@ export interface GraphNode {
   styleUrls: ['./flamegraph-visualizer.component.scss'],
 })
 export class FlamegraphVisualizerComponent {
+  @Input() set showChangeDetection(flag: boolean) {
+    this._showChangeDetection = flag;
+    this._selectFrame();
+  }
   profilerBars: FlamegraphNode[] = [];
   selectedEntry: FlamegraphNode | null = null;
 
@@ -80,11 +84,6 @@ export class FlamegraphVisualizerComponent {
 
   formatToolTip(data: any): string {
     return `${data.data.name} ${data.data.value}ms`;
-  }
-
-  updateView(event: MatCheckboxChange): void {
-    this._showChangeDetection = event.checked;
-    this._selectFrame();
   }
 
   private _selectFrame(): void {

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.html
@@ -1,6 +1,6 @@
 <ng-container [ngSwitch]="visualizationMode">
   <ng-container *ngSwitchCase="cmpVisualizationModes.FlameGraph">
-    <ng-flamegraph-visualizer [frame]="frame"></ng-flamegraph-visualizer>
+    <ng-flamegraph-visualizer [frame]="frame" [showChangeDetection]="showChangeDetection"></ng-flamegraph-visualizer>
   </ng-container>
   <ng-container *ngSwitchCase="cmpVisualizationModes.TreeMap">
     <ng-tree-map-visualizer [frame]="frame"></ng-tree-map-visualizer>

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.ts
@@ -9,6 +9,7 @@ import { ProfilerFrame } from 'protocol';
 })
 export class TimelineVisualizerComponent {
   @Input() visualizationMode: VisualizationMode;
+  @Input() showChangeDetection: boolean;
   @Input() frame: ProfilerFrame;
 
   cmpVisualizationModes = VisualizationMode;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.html
@@ -14,12 +14,24 @@
     </mat-select>
   </mat-form-field>
 
-  <label *ngIf="estimatedFrameRate >= 60"> Time spent: {{ record.duration | number }} ms </label>
-
-  <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60">
-    Time spent: {{ record.duration | number }} ms
-  </label>
-
-  <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60"> Frame rate: {{ estimatedFrameRate }} fps </label>
-  <label *ngIf="record.source">Source: {{ record.source }}</label>
+  <div class="controls-info">
+    <div class="labels">
+      <label *ngIf="estimatedFrameRate >= 60"> Time spent: {{ record.duration | number }} ms </label>
+      <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60">
+        Time spent: {{ record.duration | number }} ms
+      </label>
+      <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60">
+        Frame rate: {{ estimatedFrameRate }} fps
+      </label>
+      <label *ngIf="record.source"> Source: {{ record.source }} </label>
+    </div>
+    <div class="checkboxes">
+      <mat-checkbox (change)="hideSmallFrames.emit($event.checked)">
+        Hide small frames
+      </mat-checkbox>
+      <mat-checkbox *ngIf="visualizationMode === flameGraphMode" (change)="toggleChangeDetection.emit($event.checked)">
+        Change detection
+      </mat-checkbox>
+    </div>
+  </div>
 </div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.scss
@@ -4,6 +4,17 @@
   white-space: nowrap;
   padding: 5px;
 
+  .controls-info {
+    display: inline-flex;
+    flex-direction: column;
+
+    .checkboxes {
+      .mat-checkbox {
+        padding-right: 8px;
+      }
+    }
+  }
+
   mat-form-field {
     margin-left: 15px;
     margin-right: 15px;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.ts
@@ -14,6 +14,8 @@ export class TimelineControlsComponent {
   @Input() visualizationMode: VisualizationMode;
   @Output() changeVisualizationMode = new EventEmitter<VisualizationMode>();
   @Output() exportProfile = new EventEmitter<void>();
+  @Output() toggleChangeDetection = new EventEmitter<boolean>();
+  @Output() hideSmallFrames = new EventEmitter<boolean>();
 
   flameGraphMode = VisualizationMode.FlameGraph;
   treeMapMode = VisualizationMode.TreeMap;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
@@ -13,7 +13,9 @@
     [estimatedFrameRate]="estimateFrameRate(record.duration)"
     [visualizationMode]="visualizationMode"
     (changeVisualizationMode)="visualizationMode = $event"
-    (exportProfile)="exportProfile.emit($event)"
+    (exportProfile)="exportProfile.emit()"
+    (toggleChangeDetection)="showChangeDetection = $event"
+    (hideSmallFrames)="toggleSmallFrames($event)"
   ></ng-timeline-controls>
   <ng-frame-selector
     (move)="move($event)"
@@ -22,5 +24,9 @@
     [graphData]="graphData"
     [currentFrame]="currentFrameIndex"
   ></ng-frame-selector>
-  <ng-timeline-visualizer [visualizationMode]="visualizationMode" [frame]="record"></ng-timeline-visualizer>
+  <ng-timeline-visualizer
+    [showChangeDetection]="showChangeDetection"
+    [visualizationMode]="visualizationMode"
+    [frame]="record"
+  ></ng-timeline-visualizer>
 </ng-template>

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.module.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.module.ts
@@ -10,6 +10,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
 import { FrameSelectorComponent } from './frame-selector/frame-selector.component';
 import { TimelineControlsComponent } from './timeline-controls/timeline-controls.component';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @NgModule({
   declarations: [TimelineComponent, FrameSelectorComponent, TimelineControlsComponent],
@@ -22,6 +23,7 @@ import { TimelineControlsComponent } from './timeline-controls/timeline-controls
     MatIconModule,
     NgxFlamegraphModule,
     MatSelectModule,
+    MatCheckboxModule,
   ],
   exports: [TimelineComponent],
 })


### PR DESCRIPTION
Allows user to toggle an option in profiler to hide small frames. Under the hood this just filters out all frames that have a duration below the mean.

Closes: #278 