### PR TITLE
refactor: remove important directives and move style overrides

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card class="breadcrumb-card">
   <button mat-stroked-button color="primary" *ngFor="let node of parents" (click)="handleSelect.emit(node)">
     {{ node.original.component?.name || node.original.element }}
   </button>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
@@ -1,6 +1,6 @@
 ::ng-deep {
-  .mat-card {
-    padding: 2px 0 !important;
+  .mat-card.breadcrumb-card {
+    padding: 2px 0;
     width: 100%;
     overflow-x: auto;
     white-space: nowrap;
@@ -16,5 +16,13 @@
     font-size: 11px;
     margin-right: 5px;
     width: fit-content;
+  }
+}
+
+:host-context(.dark-theme) {
+  ::ng-deep {
+    .mat-card.breadcrumb-card span {
+      color: #ff5497;
+    }
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -108,7 +108,6 @@
     font-size: 20px;
     font-family: inherit;
     font-weight: inherit;
-    color: inherit;
     line-height: 1.4em;
     padding: 12px 6px;
   }
@@ -140,4 +139,23 @@
   padding-left: 8px;
   opacity: 0.4;
   font-style: italic;
+}
+
+:host-context(.dark-theme) {
+  .tree-node .mat-icon {
+    color: #ccc;
+  }
+
+  .tree-node .angular-element {
+    color: #7e7eff;
+  }
+
+  .tree-node.selected .angular-element {
+    color: blue;
+  }
+
+  .tree-node:hover .mat-icon,
+  .tree-node.selected .mat-icon {
+    color: #000;
+  }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
@@ -9,6 +9,7 @@
     display: flex;
     align-items: center;
     padding-right: 5px;
+    margin-left: 5px;
 
     .icon {
       width: 16px;
@@ -26,7 +27,6 @@
     font-size: 12px;
     font-family: inherit;
     font-weight: inherit;
-    color: inherit;
     height: 30px;
     outline: none;
     color: rgba(0, 0, 0, 0.87);
@@ -55,5 +55,12 @@
         }
       }
     }
+  }
+}
+
+:host-context(.dark-theme) {
+  .filter-input {
+    background-color: #424242;
+    color: #ffffff;
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
@@ -41,6 +41,17 @@
   }
 }
 
+:host-context(.dark-theme) {
+  .property-list {
+    .name {
+      color: #ffffff !important;
+    }
+    .value {
+      color: #ffffff40 !important;
+    }
+  }
+}
+
 .property-list mat-tree-node.disabled .name,
 .disabled {
   color: #333;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
@@ -1,8 +1,10 @@
 <div class="profiler-wrapper">
   <mat-card>
-    <span *ngIf="state === 'idle'" (click)="startRecording()" class="start-recording-button"></span>
-    <span *ngIf="state === 'recording'" (click)="stopRecording()" class="recording-button"></span>
-    <span *ngIf="state === 'visualizing'" (click)="discardRecording()" class="discard-button">&#10060;</span>
+    <span *ngIf="state === 'idle'" (click)="startRecording()" class="profiler-control start-recording-button"></span>
+    <span *ngIf="state === 'recording'" (click)="stopRecording()" class="profiler-control recording-button"></span>
+    <span *ngIf="state === 'visualizing'" (click)="discardRecording()" class="profiler-control discard-button"
+      >&#10060;</span
+    >
   </mat-card>
   <div id="profiler-content-wrapper">
     <p class="instructions" [class.hidden]="state !== 'idle'">

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
@@ -75,3 +75,7 @@ mat-card {
 .hidden {
   display: none;
 }
+
+.profiler-control {
+  margin-left: 8px;
+}

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bar-chart/bar-chart.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bar-chart/bar-chart.component.scss
@@ -29,3 +29,9 @@
   height: 100%;
   display: block;
 }
+
+:host-context(.dark-theme) {
+  .bar {
+    color: #424242 !important;
+  }
+}

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/tree-map-visualizer/tree-map-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/tree-map-visualizer/tree-map-visualizer.component.scss
@@ -9,3 +9,17 @@
     font-size: 12px !important;
   }
 }
+
+:host-context(.dark-theme) {
+  ::ng-deep {
+    .webtreemap-node {
+      background: #424242;
+    }
+    .webtreemap-node:hover {
+      background: #303030;
+    }
+    .webtreemap-caption {
+      color: #ffffff;
+    }
+  }
+}

--- a/projects/ng-devtools/src/lib/theme-service.ts
+++ b/projects/ng-devtools/src/lib/theme-service.ts
@@ -1,7 +1,7 @@
 import { Subject } from 'rxjs';
 import { Injectable, RendererFactory2, Renderer2 } from '@angular/core';
 
-export type Themes = 'dark' | 'light';
+export type Themes = 'dark-theme' | 'light-theme';
 
 @Injectable({
   providedIn: 'root',
@@ -17,8 +17,8 @@ export class ThemeService {
   }
 
   toggleDarkMode(isDark: boolean): void {
-    const removeClass = isDark ? 'light' : 'dark';
-    const addClass = !isDark ? 'light' : 'dark';
+    const removeClass = isDark ? 'light-theme' : 'dark-theme';
+    const addClass = !isDark ? 'light-theme' : 'dark-theme';
     this.renderer.removeClass(document.body, removeClass);
     this.renderer.addClass(document.body, addClass);
     this.currentTheme.next(addClass);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -19,37 +19,10 @@ $dark-primary: mat-palette($mat-pink, 700, 500, 900);
 $dark-accent: mat-palette($mat-blue-grey, A200, A100, A400);
 $dark-theme: mat-dark-theme($dark-primary, $dark-accent);
 
-.dark {
-  @include angular-material-theme($dark-theme);
-  .webtreemap-node {
-    background: #424242;
-  }
-  .webtreemap-node:hover {
-    background: #303030;
-  }
-  .webtreemap-caption {
-    color: #ffffff;
-  }
-  .filter-input {
-    background-color: #424242;
-    color: #ffffff;
-  }
-  .bar {
-    color: #424242 !important;
-  }
-  .label {
-    color: #424242 !important;
-  }
-  .property-list {
-    .name {
-      color: #ffffff !important;
-    }
-    .value {
-      color: #ffffff40 !important;
-    }
-  }
+.light-theme {
+  @include angular-material-theme($light-theme);
 }
 
-.light {
-  @include angular-material-theme($light-theme);
+.dark-theme {
+  @include angular-material-theme($dark-theme);
 }


### PR DESCRIPTION
This PR introduces the following improvements:
- We no longer override styles using the global `styles.scss`. This way we can leak override and have unexpected behavior.
- This allows us to remove the `!important` directives, which are considered bad practice.
- Few fixes in the contrast for some elements.