### PR TITLE
fix: property view header styling

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.html
@@ -3,7 +3,7 @@
     <mat-accordion class="property-tab-header">
       <div>
         <mat-expansion-panel [hideToggle]="true">
-          <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
+          <mat-expansion-panel-header collapsedHeight="32px" expandedHeight="32px">
             <mat-panel-title>
               <div class="element-header">
                 <div class="component-name">{{ currentSelectedElement.component.name }}</div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.scss
@@ -32,14 +32,6 @@
 
     &.mat-accordion {
       .mat-expansion-panel {
-        &:not(.mat-expanded) {
-          .mat-expansion-panel-header {
-            &:hover:not([aria-disabled='true']) {
-              background: #fff;
-            }
-          }
-        }
-
         .mat-expansion-panel-header {
           padding: 0;
 


### PR DESCRIPTION
Removes obsolete hover css that is causing contrast issues in dark mode and sets the header height to match the new search filter height for consistency.