### PR TITLE
fix: component tab color issues

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -78,3 +78,7 @@ mat-tab-group {
 .menu-toggle-button {
   font-size: 12px;
 }
+
+::ng-deep body.dark-theme .menu-toggle-button {
+  color: white;
+}

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
@@ -39,18 +39,12 @@
       font-weight: 500;
     }
   }
-  .value {
-    color: #848484 !important;
-  }
 }
 
 :host-context(.dark-theme) {
   .property-list {
     .name {
       color: #54c9bd !important;
-    }
-    .value {
-      color: #ffffff40 !important;
     }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,7 +15,7 @@ $light-accent: mat-palette($mat-teal, 300);
 $light-theme: mat-light-theme($light-primary, $light-accent);
 
 // Dark theme
-$dark-primary: mat-palette($mat-amber, 700, 500, 900);
+$dark-primary: mat-palette($mat-blue-grey, 50);
 $dark-accent: mat-palette($mat-pink, 900);
 $dark-theme: mat-dark-theme($dark-primary, $dark-accent);
 


### PR DESCRIPTION
Removes some of the fun colors to match DevTools colors, fixes bug with dark mode in menu toggle and makes preview items in property details readable with higher contrast.