### PR TITLE
feat(property-view): allow user to click on component properties of type HTMLNode to inspect the element in the browser

### DIFF
--- a/projects/ng-devtools/src/lib/application-operations.ts
+++ b/projects/ng-devtools/src/lib/application-operations.ts
@@ -3,5 +3,5 @@ import { DirectivePosition, ElementPosition } from 'protocol';
 export abstract class ApplicationOperations {
   abstract viewSource(position: ElementPosition): void;
   abstract selectDomElement(position: ElementPosition): void;
-  abstract inspectFunction(position: DirectivePosition, keyPath: string[]): void;
+  abstract inspect(directivePosition: DirectivePosition, objectPath: string[]): void;
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
@@ -15,7 +15,7 @@
     <div class="property-tab-wrapper">
       <ng-property-tab
         [currentSelectedElement]="currentSelectedElement"
-        (inspectFunction)="inspectFunction($event)"
+        (inspect)="inspect($event)"
         (viewSource)="viewSource()"
       ></ng-property-tab>
     </div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -193,8 +193,8 @@ export class DirectiveExplorerComponent implements OnInit {
     this._cdr.detectChanges();
   }
 
-  inspectFunction({ node, directivePosition }: { node: PropertyFlatNode; directivePosition: DirectivePosition }): void {
-    const keyPath = constructPathOfKeysToPropertyValue(node.prop);
-    this._appOperations.inspectFunction(directivePosition, keyPath);
+  inspect({ node, directivePosition }: { node: PropertyFlatNode; directivePosition: DirectivePosition }): void {
+    const objectPath = constructPathOfKeysToPropertyValue(node.prop);
+    this._appOperations.inspect(directivePosition, objectPath);
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="currentSelectedElement">
   <div *ngFor="let directive of getCurrentDirectives()" class="explorer-panel">
-    <ng-property-view (inspectFunction)="inspectFunction.emit($event)" [directive]="directive"></ng-property-view>
+    <ng-property-view (inspect)="inspect.emit($event)" [directive]="directive"></ng-property-view>
   </div>
 </ng-container>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-tab-body.component.ts
@@ -10,7 +10,7 @@ import { DirectivePosition } from 'protocol';
 })
 export class PropertyTabBodyComponent {
   @Input() currentSelectedElement: IndexedNode | null;
-  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
+  @Output() inspect = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   getCurrentDirectives(): string[] | undefined {
     if (!this.currentSelectedElement) {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.html
@@ -10,7 +10,7 @@
         [dataSource]="panels[index].controls.dataSource"
         [treeControl]="panels[index].controls.treeControl"
         (updateValue)="updateValue($event)"
-        (inspectFunction)="handleInspectFunction($event)"
+        (inspect)="handleInspect($event)"
       ></ng-property-view-tree>
     </mat-expansion-panel>
   </div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-body.component.ts
@@ -18,7 +18,7 @@ export class PropertyViewBodyComponent {
   @Input() directiveOutputControls: DirectiveTreeData;
   @Input() directiveStateControls: DirectiveTreeData;
 
-  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
+  @Output() inspect = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   categoryOrder = [0, 1, 2];
 
@@ -54,8 +54,8 @@ export class PropertyViewBodyComponent {
     moveItemInArray(this.categoryOrder, event.previousIndex, event.currentIndex);
   }
 
-  handleInspectFunction(node: FlatNode): void {
-    this.inspectFunction.emit({
+  handleInspect(node: FlatNode): void {
+    this.inspect.emit({
       node,
       directivePosition: this.controller.directivePosition,
     });

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
@@ -1,3 +1,3 @@
-<span class="value" [class.function]="isFunctionProp" (click)="isFunctionProp && inspectFunction.emit()">
+<span class="value" [class.function]="isClickableProp" (click)="isClickableProp && inspect.emit()">
   {{ node.prop.descriptor.preview }}
 </span>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.ts
@@ -9,9 +9,9 @@ import { FlatNode } from '../../../../../../property-resolver/element-property-r
 })
 export class PropertyPreviewComponent {
   @Input() node: FlatNode;
-  @Output() inspectFunction = new EventEmitter<void>();
+  @Output() inspect = new EventEmitter<void>();
 
-  get isFunctionProp(): boolean {
-    return this.node.prop.descriptor.type === PropType.Function;
+  get isClickableProp(): boolean {
+    return this.node.prop.descriptor.type === PropType.Function || this.node.prop.descriptor.type === PropType.HTMLNode;
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.html
@@ -2,7 +2,7 @@
   <mat-tree-node matTreeNodePaddingIndent="14" *matTreeNodeDef="let node" matTreeNodePadding>
     <span class="name non-expandable"> {{ node.prop.name }} </span>:&nbsp;
     <ng-container *ngIf="!node.prop.descriptor.editable; else editable">
-      <ng-property-preview (inspectFunction)="inspectFunction.emit(node)" [node]="node"></ng-property-preview>
+      <ng-property-preview (inspect)="inspect.emit(node)" [node]="node"></ng-property-preview>
     </ng-container>
     <ng-template #editable>
       <ng-property-editor

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.ts
@@ -12,7 +12,7 @@ export class PropertyViewTreeComponent {
   @Input() dataSource: PropertyDataSource;
   @Input() treeControl: FlatTreeControl<FlatNode>;
   @Output() updateValue = new EventEmitter<any>();
-  @Output() inspectFunction = new EventEmitter<any>();
+  @Output() inspect = new EventEmitter<any>();
 
   hasChild = (_: number, node: FlatNode): boolean => node.expandable;
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.html
@@ -4,5 +4,5 @@
   [directiveInputControls]="directiveInputControls"
   [directiveOutputControls]="directiveOutputControls"
   [directiveStateControls]="directiveStateControls"
-  (inspectFunction)="inspectFunction.emit($event)"
+  (inspect)="inspect.emit($event)"
 ></ng-property-view-body>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view.component.ts
@@ -10,7 +10,7 @@ import { DirectivePosition } from 'protocol';
 })
 export class PropertyViewComponent {
   @Input() directive: string;
-  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
+  @Output() inspect = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 
   constructor(private _nestedProps: ElementPropertyResolver) {}
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
@@ -1,7 +1,4 @@
 <ng-property-tab-header [currentSelectedElement]="currentSelectedElement" (viewSource)="viewSource.emit()">
 </ng-property-tab-header>
-<ng-property-tab-body
-  (inspectFunction)="inspectFunction.emit($event)"
-  [currentSelectedElement]="currentSelectedElement"
->
+<ng-property-tab-body (inspect)="inspect.emit($event)" [currentSelectedElement]="currentSelectedElement">
 </ng-property-tab-body>

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
@@ -10,5 +10,5 @@ import { DirectivePosition } from 'protocol';
 export class PropertyTabComponent {
   @Input() currentSelectedElement: IndexedNode;
   @Output() viewSource = new EventEmitter<void>();
-  @Output() inspectFunction = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
+  @Output() inspect = new EventEmitter<{ node: FlatNode; directivePosition: DirectivePosition }>();
 }

--- a/projects/shell-chrome/src/app/chrome-application-operations.ts
+++ b/projects/shell-chrome/src/app/chrome-application-operations.ts
@@ -14,14 +14,14 @@ export class ChromeApplicationOperations extends ApplicationOperations {
     }
   }
 
-  inspectFunction(directivePosition: DirectivePosition, keyPath: string[]): void {
+  inspect(directivePosition: DirectivePosition, objectPath: string[]): void {
     if (chrome.devtools) {
       const args = {
         directivePosition,
-        keyPath,
+        objectPath,
       };
       chrome.devtools.inspectedWindow.eval(
-        `inspect(inspectedApplication.findFunctionByPosition('${JSON.stringify(args)}'))`
+        `inspect(inspectedApplication.findPropertyByPosition('${JSON.stringify(args)}'))`
       );
     }
   }

--- a/projects/shell-chrome/src/app/chrome-window-extensions.ts
+++ b/projects/shell-chrome/src/app/chrome-window-extensions.ts
@@ -36,8 +36,8 @@ const chromeWindowExtensions = {
     }
     return node.nativeElement;
   },
-  findFunctionByPosition: (args): any => {
-    const { directivePosition, keyPath } = JSON.parse(args);
+  findPropertyByPosition: (args): any => {
+    const { directivePosition, objectPath } = JSON.parse(args);
     const node = queryDirectiveForest(directivePosition.element, buildDirectiveForest());
     if (node === null) {
       console.error(`Cannot find element associated with node ${directivePosition}`);
@@ -49,16 +49,16 @@ const chromeWindowExtensions = {
       node.directives[directivePosition.directive] &&
       typeof node.directives[directivePosition.directive] === 'object';
     if (isDirective) {
-      return traverseDirective(node.directives[directivePosition.directive].instance, keyPath);
+      return traverseDirective(node.directives[directivePosition.directive].instance, objectPath);
     }
     if (node.component) {
-      return traverseDirective(node.component.instance, keyPath);
+      return traverseDirective(node.component.instance, objectPath);
     }
   },
 };
 
-const traverseDirective = (dir: any, keyPath: string[]): any => {
-  for (const key of keyPath) {
+const traverseDirective = (dir: any, objectPath: string[]): any => {
+  for (const key of objectPath) {
     if (!dir[key]) {
       return;
     }

--- a/src/app/demo-app/demo-app.component.html
+++ b/src/app/demo-app/demo-app.component.html
@@ -1,3 +1,4 @@
 <router-outlet></router-outlet>
 <app-zippy [title]="getTitle()">This is my content</app-zippy>
 <app-heavy></app-heavy>
+<div #elementReference>HTMLElement</div>

--- a/src/app/demo-app/demo-app.component.ts
+++ b/src/app/demo-app/demo-app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ZippyComponent } from './zippy/zippy.component';
 
 @Component({
@@ -8,6 +8,7 @@ import { ZippyComponent } from './zippy/zippy.component';
 })
 export class DemoAppComponent {
   @ViewChild(ZippyComponent) zippy: ZippyComponent;
+  @ViewChild('elementReference') elementRef: ElementRef;
 
   getTitle(): '► Click to expand' | '▼ Click to collapse' {
     if (!this.zippy || !this.zippy.visible) {

--- a/src/demo-application-operations.ts
+++ b/src/demo-application-operations.ts
@@ -10,8 +10,8 @@ export class DemoApplicationOperations extends ApplicationOperations {
     console.warn('selectDomElement() is not implemented because the demo app runs in an Iframe');
     throw new Error('Not implemented in demo app.');
   }
-  inspectFunction(position: DirectivePosition, keyPath: string[]): void {
-    console.warn('inspectFunction() is not implemented because the demo app runs in an Iframe');
+  inspect(directivePosition: DirectivePosition, keyPath: string[]): void {
+    console.warn('inspect() is not implemented because the demo app runs in an Iframe');
     return;
   }
 }


### PR DESCRIPTION
Allows HTMLElements to be inspectable in the property view similar to how functions are currently.

Use case: User targets HTMLElement inside component with `@ViewChild`. They can now click directly on the nativeElement of the ElementRef property directly in the property view tab to inspect that element in the DOM. If that element is not currently on the DOM, they get the standard "Node cannot be found in the current page." console warning.