### PR TITLE
fix: lview parsing when trying to get data from an option

### DIFF
--- a/projects/ng-devtools-backend/src/lib/lview-transform.ts
+++ b/projects/ng-devtools-backend/src/lib/lview-transform.ts
@@ -97,7 +97,7 @@ const extractNodes = (lViewOrLContainer: any, nodes: ComponentTreeNode[] = []): 
   const lView = lViewOrLContainer;
   const tView = lView[LVIEW_TVIEW];
   for (let i = HEADER_OFFSET; i < lView.length; i++) {
-    if (lView[i] && lView[i][ELEMENT] instanceof Node) {
+    if (lView[i] && tView.data && lView[i][ELEMENT] instanceof Node) {
       const node = getNode(lView, tView.data, i);
 
       // TODO(mgechev): verify if this won't make us skip projected content.


### PR DESCRIPTION
Fix #513 

The `tView` in the case described in #513 is not a true `tView` but a select. Checking if we have a `data` would prevent this issue from happening. In the long run, we'll be getting the tree from the framework, which will let us remove the parsing logic.