### PR TITLE
perf(backend): prevent highlighter from rebuilding the directive forest every time a node is hovered over in the directive forest

### DIFF
--- a/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -12,7 +12,7 @@ import {
 import { ComponentTreeNode, getLatestComponentState, queryDirectiveForest, updateState } from './component-tree';
 import { start as startProfiling, stop as stopProfiling } from './hooks/capture';
 import { serializeDirectiveState } from './state-serializer/state-serializer';
-import { ComponentInspector, ComponentInspectorOptions } from './component-inspector/component-inspector';
+import { ComponentInspector } from './component-inspector/component-inspector';
 import { setConsoleReference } from './set-console-reference';
 import { unHighlight } from './highlighter';
 import {
@@ -146,18 +146,17 @@ const checkForAngular = (messageBus: MessageBus<Events>, attempt = 0): void => {
 };
 
 const setupInspector = (messageBus: MessageBus<Events>) => {
-  const onComponentEnter = (id: number) => {
-    messageBus.emit('highlightComponent', [id]);
-  };
-  const onComponentLeave = () => {
-    messageBus.emit('removeComponentHighlight');
-  };
-  const onComponentSelect = (id: number) => {
-    messageBus.emit('selectComponent', [id]);
-  };
-
-  const inspectorOptions: ComponentInspectorOptions = { onComponentEnter, onComponentLeave, onComponentSelect };
-  const inspector = new ComponentInspector(inspectorOptions);
+  const inspector = new ComponentInspector({
+    onComponentEnter: (id: number) => {
+      messageBus.emit('highlightComponent', [id]);
+    },
+    onComponentLeave: () => {
+      messageBus.emit('removeComponentHighlight');
+    },
+    onComponentSelect: (id: number) => {
+      messageBus.emit('selectComponent', [id]);
+    },
+  });
 
   messageBus.on('inspectorStart', inspector.startInspecting);
   messageBus.on('inspectorEnd', inspector.stopInspecting);

--- a/projects/ng-devtools-backend/src/lib/component-inspector/component-inspector.ts
+++ b/projects/ng-devtools-backend/src/lib/component-inspector/component-inspector.ts
@@ -1,6 +1,6 @@
 import { unHighlight, highlight, findComponentAndHost } from '../highlighter';
 import { Type } from '@angular/core';
-import { buildDirectiveForest, ComponentTreeNode, findNodeInForest } from '../component-tree';
+import { ComponentTreeNode, findNodeInForest } from '../component-tree';
 import { ElementPosition } from 'protocol';
 import { initializeOrGetDirectiveForestHooks } from '../hooks';
 
@@ -80,7 +80,7 @@ export class ComponentInspector {
   }
 
   highlightByPosition(position: ElementPosition): void {
-    const forest: ComponentTreeNode[] = buildDirectiveForest();
+    const forest: ComponentTreeNode[] = initializeOrGetDirectiveForestHooks().getDirectiveForest();
     const elementToHighlight: HTMLElement | null = findNodeInForest(position, forest);
     if (elementToHighlight) {
       highlight(elementToHighlight);


### PR DESCRIPTION
I noticed while using devtools on a larger app that the highlighter was extremely slow when hovering over nodes in the directive forest explorer. Tracked this issue to a line of code that builds the directive forest every time the "createHighlightOverlay" event is fired. I can't think of a case where this is necessary to do when highlighting from the directive forest, since the forest should already reflect the most up to date DOM.