### PR TITLE
fix(profiler): fix case where the state of the change detection checkbox in the flamegraph is lost when the component is destroyed

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.html
@@ -13,26 +13,32 @@
     </mat-select>
   </mat-form-field>
 
-  <div class="details" 
+  <div
+    class="details"
     [class.flame-details]="visualizationMode == flameGraphMode"
-    [class.bar-details]="visualizationMode == barGraphMode">
+    [class.bar-details]="visualizationMode == barGraphMode"
+  >
     <label *ngIf="estimatedFrameRate >= 60 && record">
       Time spent: <span class="value">{{ record?.duration | number }} ms</span>
     </label>
-  
+
     <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60 && record">
       Time spent: <span class="value">{{ record?.duration | number }} ms</span>
     </label>
-  
+
     <label [style.color]="frameColor" *ngIf="estimatedFrameRate < 60 && record">
       Frame rate: <span class="value">{{ estimatedFrameRate }} fps</span>
     </label>
-  
+
     <label *ngIf="record?.source && record">
       Source: <span class="value">{{ record?.source }}</span>
     </label>
 
-    <mat-checkbox *ngIf="visualizationMode == flameGraphMode" (change)="this.toggleChangeDetection.emit($event.checked)">
+    <mat-checkbox
+      *ngIf="visualizationMode == flameGraphMode"
+      [checked]="changeDetection"
+      (change)="this.toggleChangeDetection.emit(!changeDetection)"
+    >
       Show only change detection
     </mat-checkbox>
   </div>

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.ts
@@ -13,6 +13,7 @@ export class TimelineControlsComponent {
   @Input() frameColor: string;
   @Input() visualizationMode: VisualizationMode;
   @Input() empty: boolean;
+  @Input() changeDetection: boolean;
   @Output() changeVisualizationMode = new EventEmitter<VisualizationMode>();
   @Output() exportProfile = new EventEmitter<void>();
   @Output() toggleChangeDetection = new EventEmitter<boolean>();

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.html
@@ -12,6 +12,7 @@
     [frameColor]="getColorByFrameRate(estimateFrameRate(frame?.duration))"
     [estimatedFrameRate]="estimateFrameRate(frame?.duration)"
     [visualizationMode]="visualizationMode"
+    [changeDetection]="changeDetection"
     (changeVisualizationMode)="visualizationMode = $event"
     (exportProfile)="exportProfile.emit($event)"
     (toggleChangeDetection)="changeDetection = $event"


### PR DESCRIPTION
Previously when switching between profiler visualizations this checkbox would lose its state when the flamegraph component was destroyed. Now the state from the parent timeline component is passed appropriately to the timeline-controls component.