### PR TITLE
fix: color and font sizes and other visuals

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -65,7 +65,7 @@ mat-tab-group {
       min-width: unset;
       line-height: 30px;
       height: 30px;
-      font-size: 0.9em;
+      font-size: 13px;
       padding: 0px 10px;
     }
   }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
@@ -13,7 +13,7 @@
   .mat-stroked-button {
     height: 20px;
     line-height: 20px;
-    font-size: 1em;
+    font-size: 11px;
     margin-right: 5px;
     width: fit-content;
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -9,7 +9,8 @@
 
     cursor: default;
     font-family: Menlo, monospace;
-    font-size: 0.8em;
+    font-size: 11px;
+    line-height: 18px;
 
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -42,7 +43,6 @@
 
     &:hover {
       background-color: #ebf1fb;
-      cursor: pointer;
     }
 
     &.matched {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
@@ -24,7 +24,7 @@
     border-left: 1px solid rgba(0, 0, 0, 0.12);
     padding-left: 5px;
     width: 100%;
-    font-size: 0.9em;
+    font-size: 11px;
     font-family: inherit;
     font-weight: inherit;
     height: 30px;
@@ -60,7 +60,7 @@
 
 :host-context(.dark-theme) {
   .filter-input {
-    background-color: #424242;
+    background-color: #242424;
     color: #ffffff;
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
@@ -15,7 +15,7 @@
       font-family: Menlo, monospace;
 
       .mat-icon {
-        font-size: 0.9em;
+        font-size: 11px;
         width: 8px;
         height: 16px;
       }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-header/property-view-header.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-header/property-view-header.component.scss
@@ -4,7 +4,7 @@ mat-toolbar {
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 25px;
-  font-size: 0.9em;
+  font-size: 11px;
   font-weight: 500;
   display: flex;
   align-items: center;

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/component-metadata/component-metadata.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/component-metadata/component-metadata.component.scss
@@ -5,7 +5,7 @@
 
 .meta-data-container a {
   width: 100%;
-  font-size: 0.9em;
+  font-size: 11px;
   height: 22px;
   line-height: 22px;
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header/property-tab-header.component.scss
@@ -3,7 +3,7 @@
   justify-content: space-between;
   width: 100%;
   align-items: center;
-  font-size: 0.9em;
+  font-size: 11px;
 
   .mat-icon-button {
     height: 25px;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
@@ -14,7 +14,7 @@
     text-overflow: ellipsis;
     overflow: hidden;
     line-height: 25px;
-    font-size: 0.9em;
+    font-size: 11px;
     font-weight: 500;
     display: flex;
     align-items: center;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.scss
@@ -1,5 +1,5 @@
 :host {
-  font-size: 0.9em;
+  font-size: 11px;
   width: 100%;
   height: 100%;
   display: block;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,20 @@ $light-theme: mat-light-theme($light-primary, $light-accent);
 // Dark theme
 $dark-primary: mat-palette($mat-blue-grey, 50);
 $dark-accent: mat-palette($mat-purple, 200);
+$mat-dark-theme-background: map-merge(
+  $mat-dark-theme-background,
+  (
+    background: #242424,
+    card: #242424,
+  )
+);
+$mat-dark-theme-foreground: map-merge(
+  $mat-dark-theme-foreground,
+  (
+    text: #bcc5ce,
+  )
+);
+
 $dark-theme: mat-dark-theme($dark-primary, $dark-accent);
 
 .light-theme {


### PR DESCRIPTION
Second pass on the UI changes based on comments from #597

Included:
Match directive explorer background to chrome devtools element and source explorer background (#242424 for darkmode)
Remove cursor pointer css for directive forest to match chrome devtools element explorer
Align font sizing to DevTools

Comments:
> Change css on .tree-node to have font-size 11px and line-height 15px to match up with how chrome devtools displays element nodes.

This one I'm unsure on, I went through and lined up some of the visually too large text but 11px is rather small as a hard coded default. Suggestion is to merge this change and test to see if this size fits with DevTools.

> Style split pane gutter to look like chrome devtools gutter

This is a 3p library so it's a quite hacky fix - is there a plan to keep it as is? If so I can make it wider in the next UI PR.

> Change font color for the property explorer to be the same as the font color used in chrome devtools styles explorer (for keys and values, light mode and dark mode)

This should already exist, but if it doesn't let's fix it ! Screenshots appreciated 