### PR TITLE
refactor: clean up mat-tab css

### DIFF
--- a/cypress/integration/base.e2e.js
+++ b/cypress/integration/base.e2e.js
@@ -13,11 +13,11 @@ describe('Testing the Todo app Demo', () => {
   });
 
   it('should contain the "Components" tab', () => {
-    cy.get('.mat-tab-label-content').contains('Components');
+    cy.get('.mat-tab-links').contains('Components');
   });
 
   it('should contain the "Profiler" tab', () => {
-    cy.get('.mat-tab-label-content').contains('Profiler');
+    cy.get('.mat-tab-links').contains('Profiler');
   });
 
   it('should contain "app-root" and "app-todo-demo" in the component tree', () => {

--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -1,36 +1,43 @@
-<mat-tab-group color="accent" (selectedIndexChange)="tabUpdate.notify()" animationDuration="0ms">
-  <mat-tab label="Components">
-    <ng-directive-explorer (toggleInspector)="toggleInspector()"></ng-directive-explorer>
-  </mat-tab>
-  <mat-tab label="Profiler">
-    <ng-profiler></ng-profiler>
-  </mat-tab>
-</mat-tab-group>
+<nav #navBar mat-tab-nav-bar [color]="'accent'">
+  <div id="nav-buttons">
+    <button mat-icon-button color="primary" (click)="toggleInspector()">
+      <mat-icon>
+        drag_indicator
+      </mat-icon>
+    </button>
+    <button mat-icon-button color="primary" (click)="refresh()">
+      <mat-icon>
+        refresh
+      </mat-icon>
+    </button>
+    <button mat-icon-button color="primary" [matMenuTriggerFor]="menu">
+      <mat-icon>
+        settings
+      </mat-icon>
+    </button>
+  </div>
+  <a class="mat-tab-link" mat-tab-link *ngFor="let tab of tabs" (click)="onTabChange(tab)" [active]="activeTab === tab">
+    {{ tab }}
+  </a>
+  <section *ngIf="angularVersion" id="app-angular-version">
+    Angular version:
+    <span id="version-number">
+      {{ angularVersion }}
+    </span>
+    <ng-container *ngIf="latestSHA; let sha"> | DevTools SHA: {{ sha }} </ng-container>
+  </section>
+</nav>
 
-<div id="nav-buttons">
-  <button mat-icon-button color="primary" (click)="toggleInspector()">
-    <mat-icon>
-      drag_indicator
-    </mat-icon>
-  </button>
-  <button mat-icon-button color="primary" (click)="refresh()">
-    <mat-icon>
-      refresh
-    </mat-icon>
-  </button>
-  <button mat-icon-button color="primary" [matMenuTriggerFor]="menu">
-    <mat-icon>
-      settings
-    </mat-icon>
-  </button>
+<div class="tab-content">
+  <ng-directive-explorer
+    [ngClass]="{ hidden: activeTab !== 'Components' }"
+    (toggleInspector)="toggleInspector()"
+  ></ng-directive-explorer>
+  <ng-profiler [ngClass]="{ hidden: activeTab !== 'Profiler' }"></ng-profiler>
 </div>
 
 <mat-menu #menu="matMenu" class="options-menu">
-  <mat-slide-toggle 
-    (change)="toggleTimingAPI($event)" 
-    class="menu-toggle-button" 
-    (click)="$event.stopPropagation()"
-  >
+  <mat-slide-toggle (change)="toggleTimingAPI($event)" class="menu-toggle-button" (click)="$event.stopPropagation()">
     Enable timing API
   </mat-slide-toggle>
   <br />
@@ -44,11 +51,3 @@
     Dark Mode
   </mat-slide-toggle>
 </mat-menu>
-
-<section *ngIf="angularVersion" id="app-angular-version">
-  Angular version:
-    <span id="version-number">
-      {{ angularVersion }}
-    </span>
-  <ng-container *ngIf="latestSHA; let sha"> | DevTools SHA: {{ sha }} </ng-container>
-</section>

--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -5,29 +5,27 @@
   display: block;
 }
 
-mat-tab-group {
-  width: 100%;
-  height: 100%;
-  display: block;
+.hidden {
+  display: none;
+}
+
+.tab-content {
+  height: calc(100% - 50px);
 }
 
 #nav-buttons {
   display: flex;
-  position: absolute;
-  top: 0px;
-  left: 0px;
 }
 
 #app-angular-version {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+  align-self: center;
+  margin-left: auto;
+  margin-right: 8px;
   font-size: 0.8em;
   font-weight: bold;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  z-index: 999;
 }
 
 #version-number {
@@ -40,51 +38,28 @@ mat-tab-group {
   user-select: text;
 }
 
-::ng-deep {
-  .mat-icon-button {
-    height: 30px !important;
-    width: 30px !important;
-    line-height: 30px !important;
-    margin-right: 5px !important;
-  }
-
-  .mat-tab-body-wrapper {
-    height: calc(100% - 31px);
-  }
-
-  .mat-tab-header {
-    height: 30px;
-  }
-
-  .mat-tab-label-container {
-    margin-left: 125px;
-  }
-
-  mat-tab-header {
-    .mat-tab-label {
-      min-width: unset;
-      line-height: 30px;
-      height: 30px;
-      font-size: 13px;
-      padding: 0px 10px;
-    }
-  }
+button.mat-icon-button {
+  height: 30px;
+  width: 30px;
+  line-height: 30px;
+  margin-right: 5px;
 }
 
-.menu {
-  position: absolute;
-  left: 60px;
-  top: -3px;
-  font-size: 1.5em;
-  outline: none;
-  width: 13px;
-  height: 33px;
-  padding: 0;
+.mat-tab-link {
+  min-width: unset;
+  line-height: 30px;
+  height: 30px;
+  font-size: 13px;
+  padding: 0px 10px;
 }
 
 ::ng-deep {
   .options-menu {
     padding: 1rem 1.25rem;
+  }
+
+  body.dark-theme .menu-toggle-button {
+    color: white;
   }
 }
 
@@ -100,11 +75,7 @@ mat-tab-group {
   }
 }
 
-::ng-deep body.dark-theme .menu-toggle-button {
-  color: white;
-}
-
-@media only screen and (max-width: 525px) {
+@media only screen and (max-width: 700px) {
   #app-angular-version {
     max-width: 135px;
   }

--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -1,22 +1,25 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Events, MessageBus } from 'protocol';
-import { MatTabGroup } from '@angular/material/tabs';
 import { DirectiveExplorerComponent } from './directive-explorer/directive-explorer.component';
 import { ApplicationEnvironment } from '../application-environment';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { TabUpdate } from './tab-update';
 import { Theme, ThemeService } from '../theme-service';
 import { Subscription } from 'rxjs';
+import { MatTabNav } from '@angular/material/tabs';
 
 @Component({
   selector: 'ng-devtools-tabs',
   templateUrl: './devtools-tabs.component.html',
   styleUrls: ['./devtools-tabs.component.scss'],
 })
-export class DevToolsTabsComponent implements OnInit, OnDestroy {
+export class DevToolsTabsComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() angularVersion: string | undefined = undefined;
-  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
   @ViewChild(DirectiveExplorerComponent) directiveExplorer: DirectiveExplorerComponent;
+  @ViewChild('navBar', { static: true }) navbar: MatTabNav;
+
+  tabs = ['Components', 'Profiler'];
+  activeTab: 'Components' | 'Profiler' = 'Components';
 
   inspectorRunning = false;
 
@@ -34,12 +37,21 @@ export class DevToolsTabsComponent implements OnInit, OnDestroy {
     this._currentThemeSubscription = this.themeService.currentTheme.subscribe((theme) => (this.currentTheme = theme));
   }
 
+  ngAfterViewInit(): void {
+    this.navbar.disablePagination = true;
+  }
+
   ngOnDestroy(): void {
     this._currentThemeSubscription.unsubscribe();
   }
 
   get latestSHA(): string {
     return this._applicationEnvironment.environment.process.env.LATEST_SHA;
+  }
+
+  onTabChange(tab: 'Profiler' | 'Components'): void {
+    this.activeTab = tab;
+    this.tabUpdate.notify();
   }
 
   toggleInspector(): void {
@@ -50,7 +62,7 @@ export class DevToolsTabsComponent implements OnInit, OnDestroy {
   emitInspectorEvent(): void {
     if (this.inspectorRunning) {
       this._messageBus.emit('inspectorStart');
-      this.tabGroup.selectedIndex = 0;
+      this.activeTab = 'Components';
     } else {
       this._messageBus.emit('inspectorEnd');
       this._messageBus.emit('removeHighlightOverlay');

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
@@ -4,7 +4,7 @@
   ::ng-deep {
     as-split {
       &.space-for-bread-crumbs {
-        height: calc(100% - 33px);
+        height: calc(100% - 4px);
       }
     }
 

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
@@ -2,7 +2,7 @@
 .profiler-wrapper {
   font-size: 1em;
   width: 100%;
-  height: calc(100% - 28px);
+  height: calc(100% - 30px);
 }
 
 .mat-card {


### PR DESCRIPTION
Removes some absolute positioning by refactoring mat tab header. Removes some dead css