### PR TITLE
fix: theming of profiler tab (focus on dark mode)

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/breadcrumbs/breadcrumbs.component.scss
@@ -30,7 +30,7 @@
 :host-context(.dark-theme) {
   ::ng-deep {
     .mat-card.breadcrumb-card span {
-      color: #5caace;
+      color: #5cadd3;
     }
 
     .mat-stroked-button {

--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -65,8 +65,7 @@
     background-color: transparent;
   }
   50% {
-    background-color: #fecf4a;
-    color: #748591;
+    background-color: #cfe8fc;
   }
   100% {
     background-color: transparent;
@@ -124,9 +123,12 @@
 }
 
 :host-context(.dark-theme) {
-  .tree-node,
-  .tree-node .mat-icon {
+  .tree-node {
     color: #5cadd3;
+
+    .mat-icon {
+      color: #bcc5ce;
+    }
 
     .dir-names {
       color: #91adcb;
@@ -141,7 +143,7 @@
     }
 
     &.matched {
-      background-color: #093e69;
+      background-color: #262d36;
 
       &:hover {
         background-color: #073d69;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
@@ -1,18 +1,33 @@
 <div class="profiler-wrapper">
   <mat-card>
-    <mat-icon *ngIf="state === 'idle'" (click)="startRecording()" class="profiler-control start-recording-button">
-      play_circle_outline
-    </mat-icon>
-    <mat-icon *ngIf="state === 'recording'" (click)="stopRecording()" class="profiler-control recording-button">
-      stop_circle
-    </mat-icon>
-    <mat-icon *ngIf="state === 'visualizing'" (click)="discardRecording()" class="profiler-control discard-button">
-      refresh
-    </mat-icon>
+    <button
+      mat-icon-button
+      color="primary"
+      *ngIf="state === 'idle'"
+      (click)="startRecording()"
+      class="profiler-control start-recording-button"
+    >
+      <mat-icon> circle </mat-icon>
+    </button>
+    <button
+      mat-icon-button
+      *ngIf="state === 'recording'"
+      (click)="stopRecording()"
+      class="profiler-control recording-button"
+    >
+      <mat-icon> circle </mat-icon>
+    </button>
+    <button
+      mat-icon-button
+      color="primary"
+      *ngIf="state === 'visualizing'"
+      (click)="discardRecording()"
+      class="profiler-control discard-button"
+    >
+      <mat-icon> not_interested </mat-icon>
+    </button>
     <p class="instructions" [class.hidden]="state !== 'idle'">
-      <span>
-        Click the play button to start a new recording, or upload a json file containing profiler data.
-      </span>
+      <span> Click the play button to start a new recording, or upload a json file containing profiler data. </span>
       <br />
       <span>
         <input type="file" (change)="importProfilerResults($event)" placeholder="Upload file" accept=".json" />

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
@@ -15,13 +15,12 @@
   border-radius: 0;
 }
 
-.profiler-control {
-  padding: 8px;
-  cursor: pointer;
+.mat-icon {
+  font-size: 18px;
+}
 
-  &.start-recording-button {
-    color: #4db675;
-  }
+.profiler-control {
+  cursor: pointer;
 
   &.recording-button {
     color: #d83c34;

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/frame-selector/frame-selector.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/frame-selector/frame-selector.component.scss
@@ -39,16 +39,37 @@
       margin-right: 2.5px;
       margin-top: 2px;
 
+      &:hover {
+        background-color: #ebf1fb;
+      }
+
       &.selected {
-        margin-left: 0.5px;
-        margin-right: 0.5px;
+        margin-left: 0;
+        margin-right: 0;
         margin-top: 0;
-        border: 2px solid #ffc400;
+        padding-left: 0.5px;
+        padding-right: 0.5px;
+
+        background-color: #cfe8fc;
+        border: 2px solid #cfe8fc;
       }
     }
   }
 
   button {
     margin-bottom: 5px;
+  }
+}
+
+:host-context(.dark-theme) {
+  .bar-graph-container .bar-container .frame-bar {
+    &:hover {
+      background-color: #262d36;
+    }
+
+    &.selected {
+      background-color: #073d69;
+      border: 2px solid #073d69;
+    }
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/flamegraph-formatter/flamegraph-formatter.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/record-formatter/flamegraph-formatter/flamegraph-formatter.ts
@@ -1,5 +1,6 @@
 import { RecordFormatter } from '../record-formatter';
 import { ElementProfile, ProfilerFrame } from 'protocol';
+import { Theme } from 'projects/ng-devtools/src/lib/theme-service';
 
 export interface FlamegraphNode {
   value: number;
@@ -14,12 +15,11 @@ export interface FlamegraphNode {
 export const ROOT_LEVEL_ELEMENT_LABEL = 'Entire application';
 
 export class FlamegraphFormatter extends RecordFormatter<FlamegraphNode> {
-  formatFrame(frame: ProfilerFrame, showChangeDetection?: boolean): FlamegraphNode {
+  formatFrame(frame: ProfilerFrame, showChangeDetection?: boolean, theme?: Theme): FlamegraphNode {
     const result: FlamegraphNode = {
       value: 0,
       label: ROOT_LEVEL_ELEMENT_LABEL,
       children: [],
-      color: '#4db6ac',
       instances: 1,
       changeDetected: false,
       original: {
@@ -28,11 +28,15 @@ export class FlamegraphFormatter extends RecordFormatter<FlamegraphNode> {
       },
     };
 
-    this.addFrame(result.children, frame.directives, showChangeDetection);
+    if (showChangeDetection) {
+      result.color = theme === 'dark-theme' ? CHANGE_DETECTION_COLOR_DARK : CHANGE_DETECTION_COLOR_LIGHT;
+    }
+
+    this.addFrame(result.children, frame.directives, showChangeDetection, theme);
     return result;
   }
 
-  addFrame(nodes: FlamegraphNode[], elements: ElementProfile[], showChangeDetection?: boolean): number {
+  addFrame(nodes: FlamegraphNode[], elements: ElementProfile[], showChangeDetection?: boolean, theme?: Theme): number {
     let timeSpent = 0;
     elements.forEach((element) => {
       // Possibly undefined because of
@@ -51,9 +55,11 @@ export class FlamegraphFormatter extends RecordFormatter<FlamegraphNode> {
         changeDetected,
       };
       if (showChangeDetection) {
+        const CHANGE_DETECTION_COLOR =
+          theme === 'dark-theme' ? CHANGE_DETECTION_COLOR_DARK : CHANGE_DETECTION_COLOR_LIGHT;
         node.color = changeDetected ? CHANGE_DETECTION_COLOR : NO_CHANGE_DETECTION_COLOR;
       }
-      timeSpent += this.addFrame(node.children, element.children, showChangeDetection);
+      timeSpent += this.addFrame(node.children, element.children, showChangeDetection, theme);
       timeSpent += node.value;
       nodes.push(node);
     });
@@ -61,8 +67,9 @@ export class FlamegraphFormatter extends RecordFormatter<FlamegraphNode> {
   }
 }
 
-const CHANGE_DETECTION_COLOR = '#4db675';
-const NO_CHANGE_DETECTION_COLOR = '#FAFAFA';
+const CHANGE_DETECTION_COLOR_LIGHT = '#5cadd3';
+const CHANGE_DETECTION_COLOR_DARK = '#073d69';
+const NO_CHANGE_DETECTION_COLOR = 'transparent';
 
 const didRunChangeDetection = (profile: ElementProfile) => {
   const components = profile.directives.filter((d) => d.isComponent);

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bar-chart/bar-chart.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bar-chart/bar-chart.component.scss
@@ -5,7 +5,7 @@
   display: flex;
   padding-top: 3px;
   padding-bottom: 3px;
-  opacity: 0.7;
+  opacity: 0.8;
   cursor: pointer;
   transition: opacity 0.3s ease-out, width 0.3s ease;
 }
@@ -33,6 +33,6 @@
 
 :host-context(.dark-theme) {
   .bar span {
-    color: black !important;
+    color: #bcc5ce;
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bargraph-visualizer/bargraph-visualizer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/bargraph-visualizer/bargraph-visualizer.component.ts
@@ -1,23 +1,40 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { BargraphNode, BarGraphFormatter } from '../../record-formatter/bargraph-formatter';
 import { ProfilerFrame } from 'protocol';
 import { SelectedDirective, SelectedEntry } from '../timeline-visualizer.component';
+import { Theme, ThemeService } from 'projects/ng-devtools/src/lib/theme-service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'ng-bargraph-visualizer',
   templateUrl: './bargraph-visualizer.component.html',
   styleUrls: ['./bargraph-visualizer.component.scss'],
 })
-export class BargraphVisualizerComponent {
-  barColor = '#FFC400';
+export class BargraphVisualizerComponent implements OnInit, OnDestroy {
+  barColor: String;
   profileRecords: BargraphNode[];
 
   @Output() nodeSelect = new EventEmitter<SelectedEntry>();
 
   private _formatter = new BarGraphFormatter();
+  private _currentThemeSubscription: Subscription;
+  currentTheme: Theme;
 
   @Input() set frame(data: ProfilerFrame) {
     this.profileRecords = this._formatter.formatFrame(data);
+  }
+
+  constructor(public themeService: ThemeService) {}
+
+  ngOnInit(): void {
+    this._currentThemeSubscription = this.themeService.currentTheme.subscribe((theme) => {
+      this.currentTheme = theme;
+      this.barColor = theme === 'dark-theme' ? '#073d69' : '#cfe8fc';
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._currentThemeSubscription.unsubscribe();
   }
 
   formatEntryData(bargraphNode: BargraphNode): SelectedDirective[] {

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.scss
@@ -5,33 +5,36 @@
   -webkit-user-select: text;
   -ms-user-select: text;
   user-select: text;
-}
 
-::ng-deep {
-  .level-profile-wrapper {
-    height: 100%;
-    width: 100%;
-    cursor: pointer;
-  }
+  ::ng-deep {
+    .level-profile-wrapper {
+      height: 100%;
+      width: 100%;
+      cursor: pointer;
+    }
 
-  .label {
-    color: #000 !important;
-    font-size: 0.8em !important;
-    opacity: 0.9;
-    padding-left: 2px;
-  }
-}
-
-:host-context(.dark-theme) {
-  .entry-statistics {
-    span {
-      color: #54c9bd;
+    .ngx-fg-label {
+      color: #000000de;
+      font-weight: 500;
+      font-size: 1em;
     }
   }
 
-  ::ng-deep {
-    rect {
-      stroke: #303030;
+  :host-context(.dark-theme) {
+    .entry-statistics {
+      span {
+        color: #54c9bd;
+      }
+    }
+
+    ::ng-deep {
+      .ngx-fg-rect {
+        stroke: #303030;
+      }
+
+      .ngx-fg-label {
+        color: #bcc5ce;
+      }
     }
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
@@ -47,7 +47,7 @@
   }
 
   span {
-    color: #880e4f;
+    color: #8a1882;
   }
 }
 
@@ -64,7 +64,7 @@ ul {
 :host-context(.dark-theme) {
   .entry-statistics {
     span {
-      color: #54c9bd;
+      color: #5cadd3;
     }
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline-controls/timeline-controls.component.scss
@@ -41,7 +41,7 @@
     }
 
     .value {
-      color: #880e4f;
+      color: #8a1882;
     }
   }
 
@@ -56,6 +56,6 @@
 
 :host-context(.dark-theme) {
   .details .value {
-    color: #54c9bd;
+    color: #5cadd3;
   }
 }

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/timeline.component.ts
@@ -62,13 +62,13 @@ export class TimelineComponent implements OnDestroy {
 
   getColorByFrameRate(framerate: number): string {
     if (framerate >= 60) {
-      return '#4db6ac';
+      return '#5cadd3';
     } else if (framerate < 60 && framerate >= 30) {
-      return '#FFBE2F';
+      return '#8a1882';
     } else if (framerate < 30 && framerate >= 15) {
-      return '#ff8d00';
+      return '#9b4807';
     }
-    return '#FF625A';
+    return '#ce271e';
   }
 
   ngOnDestroy(): void {
@@ -114,7 +114,7 @@ export class TimelineComponent implements OnDestroy {
     const backgroundColor = this.getColorByFrameRate(this.estimateFrameRate(record.duration));
 
     const style = {
-      background: `-webkit-linear-gradient(bottom, ${backgroundColor} ${colorPercentage}%, transparent ${colorPercentage}%)`,
+      'background-image': `-webkit-linear-gradient(bottom, ${backgroundColor} ${colorPercentage}%, transparent ${colorPercentage}%)`,
       cursor: 'pointer',
       'min-width': '25px',
       width: '25px',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,12 +11,12 @@ body {
 
 // Light theme
 $light-primary: mat-palette($mat-grey, 700, 200);
-$light-accent: mat-palette($mat-teal, 300);
+$light-accent: mat-palette($mat-blue, 800);
 $light-theme: mat-light-theme($light-primary, $light-accent);
 
 // Dark theme
 $dark-primary: mat-palette($mat-blue-grey, 50);
-$dark-accent: mat-palette($mat-purple, 200);
+$dark-accent: mat-palette($mat-blue, 200);
 $mat-dark-theme-background: map-merge(
   $mat-dark-theme-background,
   (


### PR DESCRIPTION
themes profiler flame graph in dark mode
themes bar graph and keyframes in dark mode
continues the alignment to dark mode
changes base theming to match consistent (boring and reasonable) color scheme
fixes #624 