### PR TITLE
fix: bump up the split pane gutter size for the profiler split pane and hide the icon

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.html
@@ -1,4 +1,4 @@
-<as-split unit="percent" [gutterSize]="2.5">
+<as-split unit="percent" [gutterSize]="9">
   <as-split-area size="75">
     <ng-container [ngSwitch]="_visualizationMode">
       <ng-container *ngSwitchCase="cmpVisualizationModes.FlameGraph">

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/timeline-visualizer.component.scss
@@ -2,6 +2,12 @@
   height: calc(100% - 2 * 60px);
   display: block;
   overflow: auto;
+
+  ::ng-deep {
+    .as-split-gutter-icon {
+      display: none;
+    }
+  }
 }
 
 .selected-entry {


### PR DESCRIPTION
- Aligns profiler split pane gutter style with the updated styles for the directory explorer.