### PR TITLE
feat: change flamegraph component input to have it be responsive by default

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.html
@@ -2,7 +2,6 @@
   <ngx-flamegraph
     (frameClick)="selectFrame($event)"
     [config]="{ data: profilerBars, color: colors }"
-    [width]="availableWidth"
     siblingLayout="equal"
   >
   </ngx-flamegraph>

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 
 import {
   FlamegraphNode,
@@ -45,7 +45,7 @@ export class FlamegraphVisualizerComponent implements OnInit, OnDestroy {
     this._selectFrame();
   }
 
-  constructor(public themeService: ThemeService, private _el: ElementRef) {}
+  constructor(public themeService: ThemeService) {}
 
   ngOnInit(): void {
     this._currentThemeSubscription = this.themeService.currentTheme.subscribe((theme) => {
@@ -68,10 +68,6 @@ export class FlamegraphVisualizerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this._currentThemeSubscription.unsubscribe();
-  }
-
-  get availableWidth(): number {
-    return this._el.nativeElement.querySelector('.level-profile-wrapper').offsetWidth;
   }
 
   selectFrame(frame: RawData): void {


### PR DESCRIPTION
closes #630 

Uses new functionality from [ngx-flamegraph](https://github.com/mgechev/ngx-flamegraph) to make flamegraph responsive by default