### PR TITLE
fix(tabs): call change tab helper when tab changes as a result of the inspector being selected

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -16,7 +16,7 @@
       </mat-icon>
     </button>
   </div>
-  <a class="mat-tab-link" mat-tab-link *ngFor="let tab of tabs" (click)="onTabChange(tab)" [active]="activeTab === tab">
+  <a class="mat-tab-link" mat-tab-link *ngFor="let tab of tabs" (click)="changeTab(tab)" [active]="activeTab === tab">
     {{ tab }}
   </a>
   <section *ngIf="angularVersion" id="app-angular-version">

--- a/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -61,7 +61,7 @@ export class DevToolsTabsComponent implements OnInit, OnDestroy, AfterViewInit {
     return this._applicationEnvironment.environment.process.env.LATEST_SHA;
   }
 
-  onTabChange(tab: 'Profiler' | 'Components' | 'Router Tree'): void {
+  changeTab(tab: 'Profiler' | 'Components' | 'Router Tree'): void {
     this.activeTab = tab;
     this.tabUpdate.notify();
     if (tab === 'Router Tree') {
@@ -77,7 +77,7 @@ export class DevToolsTabsComponent implements OnInit, OnDestroy, AfterViewInit {
   emitInspectorEvent(): void {
     if (this.inspectorRunning) {
       this._messageBus.emit('inspectorStart');
-      this.activeTab = 'Components';
+      this.changeTab('Components');
     } else {
       this._messageBus.emit('inspectorEnd');
       this._messageBus.emit('removeHighlightOverlay');


### PR DESCRIPTION
For reasoning behind why this is necessary, look at the `tabUpdate.notify()` call in `changeTab()` and then read the following comment

https://github.com/rangle/angular-devtools/blob/b76b04adfc8d7e1c520bdf878fccacc102234aa2/projects/ng-devtools/src/lib/devtools-tabs/tab-update.ts#L4-L7
