### PR TITLE
feat(extension): add opening instructions

### DIFF
--- a/projects/shell-chrome/src/popups/supported.html
+++ b/projects/shell-chrome/src/popups/supported.html
@@ -44,7 +44,10 @@
       <h4 class="header-text">Angular DevTools</h4>
       <div class="message">
         <img class="icon" src="/assets/check.png" />
-        <p>Angular application running development mode.</p>
+        <section>
+          <p>Angular application running development mode.</p>
+          <p>Open developer tools, and select the Angular tab.</p>
+        </section>
       </div>
     </div>
   </body>


### PR DESCRIPTION
adding the smallest PR to have instructions on opening DevTools if Angular devtools are enabled - in the future it might be cool to link to a demo video or something here on how to use DevTools?