### PR TITLE
Patch LTree Bug

### DIFF
--- a/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -122,6 +122,8 @@ export class LTreeStrategy {
   }
 
   build(element: Element, nodes: ComponentTreeNode[] = []): ComponentTreeNode[] {
-    return this._extract((element as any).__ngContext__);
+    const ctx = (element as any).__ngContext__;
+    const rootLView = ctx.lView ?? ctx;
+    return this._extract(rootLView);
   }
 }


### PR DESCRIPTION
Logic now assumes that the ng context of the root element is a context object, then tries to grab the LView from it, and falls back to assuming that the ng context is the LView if the `lView` attribute is not present.