### PR TITLE
Implement strategy to grab router instance from RouterLinkWithHref

### DIFF
--- a/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -11,7 +11,7 @@ import {
   Route,
 } from 'protocol';
 import { ComponentTreeNode, getLatestComponentState, queryDirectiveForest, updateState } from './component-tree';
-import { parseRoutes } from './router-tree';
+import { findRouter, parseRoutes } from './router-tree';
 import { start as startProfiling, stop as stopProfiling } from './hooks/capture';
 import { serializeDirectiveState } from './state-serializer/state-serializer';
 import { ComponentInspector } from './component-inspector/component-inspector';
@@ -140,11 +140,13 @@ const getNestedPropertiesCallback = (messageBus: MessageBus<Events>) => (
 // Subscribe Helpers
 //
 const getRoutes = (messageBus: MessageBus<Events>) => {
-  const node = queryDirectiveForest([0], initializeOrGetDirectiveForestHooks().getIndexedDirectiveForest());
   let routes: Route[] = [];
-  if (node?.component?.instance?.router) {
-    routes = [parseRoutes(node?.component?.instance?.router)];
+
+  const router = findRouter(initializeOrGetDirectiveForestHooks().getIndexedDirectiveForest());
+  if (router) {
+    routes = [parseRoutes(router)];
   }
+
   messageBus.emit('updateRouterTree', [routes]);
 };
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,8 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
-  constructor(public router: Router) {}
-}
+export class AppComponent {}


### PR DESCRIPTION
This PR changes the find router logic so that it first checks the root component for a `router` property, and if that fails, tries to find a `RouterLinkWithHref` directive in the directive forest to pick the router out of.

I'm a little concerned that our approaches to finding the router might be becoming too arbitrary. It might be hard to explain to users why their router tree tab appears in some apps but not others. Maybe we could make it clear in the documentation that the router tree is experimental for now.

I opened this PR so that we could have a reference to look at. We can close it if we deem the router finding approach too arbitrary. Curious what everyone thinks.

@twerske 
@sumitarora 
@mgechev 