### PR TITLE
fix(backend): prevent directive forest hooks from being initiated in production applications

### DIFF
--- a/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -151,9 +151,11 @@ const checkForAngular = (messageBus: MessageBus<Events>): void => {
     setTimeout(() => checkForAngular(messageBus), 500);
     return;
   }
-  if (appIsIvy) {
+
+  if (appIsIvy && appIsAngularInDevMode() && appIsSupportedAngularVersion()) {
     initializeOrGetDirectiveForestHooks();
   }
+
   messageBus.emit('ngAvailability', [
     { version: ngVersion.toString(), devMode: appIsAngularInDevMode(), ivy: appIsIvy },
   ]);


### PR DESCRIPTION
closes #694 