### PR TITLE
fix(backend): don't access injected service properties unnecessarily

### DIFF
--- a/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -108,13 +108,14 @@ export class LTreeStrategy {
     const lView = lViewOrLContainer;
     const tView = lView[LVIEW_TVIEW];
     for (let i = HEADER_OFFSET; i < lView.length; i++) {
-      if (lView[i] && tView.data && lView[i][ELEMENT] instanceof Node) {
+      const lViewItem = lView[i];
+      if (tView.data && Array.isArray(lViewItem) && lViewItem[ELEMENT] instanceof Node) {
         const node = this._getNode(lView, tView.data, i);
 
         // TODO(mgechev): verify if this won't make us skip projected content.
         if (node.component || node.directives.length) {
           nodes.push(node);
-          this._extract(lView[i], node.children);
+          this._extract(lViewItem, node.children);
         }
       }
     }


### PR DESCRIPTION
The code was requesting index 0 of each item in the LView before checking
if it is an array. This causes issues with services that only allow calls to
properties that are defined on the service (backed by a strict ES6 proxy).
A check if the type is Array first corrects this issue.

fixes issue #802