### PR TITLE
fix(backend): skip node if there is no associated TViewData

### DIFF
--- a/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -71,22 +71,29 @@ export class LTreeStrategy {
     const tNode = data[idx];
     const node = lView[idx][ELEMENT];
     const element = (node.tagName || node.nodeName).toLowerCase();
-    if (tNode) {
-      for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
-        const instance = lView[i];
-        const dirMeta = data[i];
-        if (dirMeta && dirMeta.template) {
-          component = {
-            name: element,
-            isElement: isCustomElement(node),
-            instance,
-          };
-        } else if (dirMeta) {
-          directives.push({
-            name: getDirectiveName(instance),
-            instance,
-          });
-        }
+    if (!tNode) {
+      return {
+        nativeElement: node,
+        children: [],
+        element,
+        directives: [],
+        component: null,
+      };
+    }
+    for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
+      const instance = lView[i];
+      const dirMeta = data[i];
+      if (dirMeta && dirMeta.template) {
+        component = {
+          name: element,
+          isElement: isCustomElement(node),
+          instance,
+        };
+      } else if (dirMeta) {
+        directives.push({
+          name: getDirectiveName(instance),
+          instance,
+        });
       }
     }
     return {

--- a/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -71,24 +71,26 @@ export class LTreeStrategy {
     const tNode = data[idx];
     const node = lView[idx][ELEMENT];
     const element = (node.tagName || node.nodeName).toLowerCase();
-    for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
-      const instance = lView[i];
-      const dirMeta = data[i];
-      if (dirMeta && dirMeta.template) {
-        component = {
-          name: element,
-          isElement: isCustomElement(node),
-          instance,
-        };
-      } else if (dirMeta) {
-        directives.push({
-          name: getDirectiveName(instance),
-          instance,
-        });
+    if (tNode) {
+      for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
+        const instance = lView[i];
+        const dirMeta = data[i];
+        if (dirMeta && dirMeta.template) {
+          component = {
+            name: element,
+            isElement: isCustomElement(node),
+            instance,
+          };
+        } else if (dirMeta) {
+          directives.push({
+            name: getDirectiveName(instance),
+            instance,
+          });
+        }
       }
     }
     return {
-      nativeElement: lView[idx][ELEMENT],
+      nativeElement: node,
       children: [],
       element,
       directives,


### PR DESCRIPTION
The code was assuming that the TViewData item at the same index as the node
in LView would contain a data entry. This value can be `null` (which is the
case in our app), which causes a catastrophic failure in the dev tool. By
checking for null, the node is skipped because it cannot determine the
associated component or directive and the dev tool does not die.

fixes issue #801