### PR TITLE
fix: delayed angular detection with app_initializer

### DIFF
--- a/projects/shell-chrome/src/app/ng-validate.ts
+++ b/projects/shell-chrome/src/app/ng-validate.ts
@@ -44,6 +44,10 @@ function detectAngular(win: Window): void {
     } as AngularDetection,
     '*'
   );
+
+  if (!isAngular) {
+    setTimeout(() => detectAngular(win), 1000);
+  }
 }
 
 function installScript(fn: string): void {


### PR DESCRIPTION
This PR sets a timeout for repetitive check if there's an Angular app
on the page. Fix #826.