### PR TITLE
refactor: switch to sass use and new angular material theming API

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,6 +26,9 @@
             "aot": true,
             "assets": ["src/assets"],
             "styles": ["src/styles.scss"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules"]
+            },
             "scripts": []
           },
           "configurations": {
@@ -105,6 +108,9 @@
             "karmaConfig": "karma.conf.js",
             "assets": ["src/assets"],
             "styles": ["src/styles.scss"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules"]
+            },
             "scripts": []
           }
         },
@@ -158,6 +164,9 @@
               "projects/shell-chrome/src/popups"
             ],
             "styles": ["projects/shell-chrome/src/styles.scss"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules"]
+            },
             "scripts": []
           },
           "configurations": {
@@ -220,6 +229,9 @@
             "karmaConfig": "projects/shell-chrome/karma.conf.js",
             "assets": ["projects/shell-chrome/src/assets"],
             "styles": ["projects/shell-chrome/src/styles.scss"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules"]
+            },
             "scripts": []
           }
         },
@@ -277,7 +289,10 @@
             "main": "projects/ng-devtools/src/test.ts",
             "tsConfig": "projects/ng-devtools/tsconfig.spec.json",
             "karmaConfig": "projects/ng-devtools/karma.conf.js",
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules"]
+            }
           }
         },
         "lint": {

--- a/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-modal/recording-modal.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording/timeline/recording-modal/recording-modal.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../../../node_modules/@angular/cdk/overlay-prebuilt.css';
+@use '@angular/cdk/overlay-prebuilt.css';
 
 :host {
   overflow: hidden;

--- a/projects/shell-chrome/src/styles.scss
+++ b/projects/shell-chrome/src/styles.scss
@@ -1,5 +1,4 @@
-@import '@angular/material/prebuilt-themes/deeppurple-amber.css';
-@import '../../../src/styles.scss';
+@use '../../../src/styles.scss';
 
 html {
   background-color: white;

--- a/src/app/demo-app/demo-app.component.scss
+++ b/src/app/demo-app/demo-app.component.scss
@@ -1,6 +1,2 @@
 @import 'todomvc-common/base.css';
 @import 'todomvc-app-css/index.css';
-
-body {
-  max-width: 500px !important;
-}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,42 +1,47 @@
-@import '~@angular/material/theming';
-@include mat-core();
+@use 'sass:map';
+@use '~@angular/material' as mat;
+@include mat.core();
 
 html,
 body {
   padding: 0;
   margin: 0;
-  max-width: unset !important;
-  background: white !important;
 }
 
 // Light theme
-$light-primary: mat-palette($mat-grey, 700, 200);
-$light-accent: mat-palette($mat-blue, 800);
-$light-theme: mat-light-theme($light-primary, $light-accent);
+$light-primary: mat.define-palette(mat.$grey-palette, 700, 200);
+$light-accent: mat.define-palette(mat.$blue-palette, 800);
+$light-theme: mat.define-light-theme($light-primary, $light-accent);
 
 // Dark theme
-$dark-primary: mat-palette($mat-blue-grey, 50);
-$dark-accent: mat-palette($mat-blue, 200);
-$mat-dark-theme-background: map-merge(
-  $mat-dark-theme-background,
+$dark-primary: mat.define-palette(mat.$blue-grey-palette, 50);
+$dark-accent: mat.define-palette(mat.$blue-palette, 200);
+$dark-theme: map.deep-merge(
+  mat.define-dark-theme($dark-primary, $dark-accent),
   (
-    background: #202124,
-    card: #202124,
+    'color': (
+      'background': (
+        background: #202124,
+        card: #202124,
+      ),
+      'foreground': (
+        text: #bcc5ce,
+      ),
+    ),
+    'background': (
+      background: #202124,
+      card: #202124,
+    ),
+    'foreground': (
+      'text': #bcc5ce,
+    ),
   )
 );
-$mat-dark-theme-foreground: map-merge(
-  $mat-dark-theme-foreground,
-  (
-    text: #bcc5ce,
-  )
-);
-
-$dark-theme: mat-dark-theme($dark-primary, $dark-accent);
 
 .light-theme {
-  @include angular-material-theme($light-theme);
+  @include mat.all-component-themes($light-theme);
 }
 
 .dark-theme {
-  @include angular-material-theme($dark-theme);
+  @include mat.all-component-themes($dark-theme);
 }


### PR DESCRIPTION
Previously we were using sass import rules to bring in material and other styling.

Now we are using the use rule and have switched over to the new angular material theming API

Also cleans up some old css.

See https://github.com/angular/components/pull/22173