### PR TITLE
fix: prevent mat button css from leaking out of property view header

### DIFF
--- a/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-header/property-view-header.component.scss
+++ b/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-body/property-view/property-view-header/property-view-header.component.scss
@@ -1,29 +1,10 @@
 mat-toolbar {
-  padding-left: 9px;
-  white-space: nowrap;
+  padding-left: 10px;
+  display: block;
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 25px;
   font-size: 11px;
   font-weight: 500;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   height: auto;
-}
-
-::ng-deep {
-  .mat-button {
-    height: 18px;
-    width: 18px;
-    line-height: 15px;
-    margin-right: 7px;
-  }
-
-  .mat-icon-button {
-    height: 18px;
-    width: 18px;
-    line-height: 15px;
-    margin-right: 7px;
-  }
 }


### PR DESCRIPTION
Previously, the property view header component had mat button styling nested in an ng-deep selector. This broke some styling in the info menu whenever an item was selected in the component explorer (because the existence of a selected component causes the property view header tab to render and thus brings in the leaky component css).

Now the leaky styling has been removed, and the component css has been cleaned up.