### PR TITLE
fix: show the date property value in preview (#880)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:shared-utils": "ng test shared-utils --watch=false",
     "test:protocol": "ng test protocol --watch=false",
     "test:ci": "npm run test:backend && npm run test:devtools && npm run test:shared-utils && npm run test:protocol",
-    "prettier": "prettier --write \"{,!(node_modules|dist|build|coverage)/**/}*.{js,jsx,ts,tsx,json}\"",
+    "prettier": "prettier --write \"{,!(.angular|node_modules|dist|build|coverage)/**/}*.{js,jsx,ts,tsx,json}\"",
     "prettier:fix": "pretty-quick --staged"
   },
   "husky": {

--- a/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -51,7 +51,12 @@ const typeToDescriptorPreview: Formatter<string> = {
   [PropType.Object]: (prop: any) => (getKeys(prop).length > 0 ? '{...}' : '{}'),
   [PropType.Symbol]: (_: any) => 'Symbol()',
   [PropType.Undefined]: (_: any) => 'undefined',
-  [PropType.Date]: (_: any) => 'Date()',
+  [PropType.Date]: (prop: any) => {
+    if (prop instanceof Date) {
+      return `Date(${new Date(prop).toISOString()})`;
+    }
+    return prop;
+  },
   [PropType.Unknown]: (_: any) => 'unknown',
 };
 
@@ -76,7 +81,7 @@ const shallowPropTypeToTreeMetaData = {
     expandable: false,
   },
   [PropType.Date]: {
-    editable: true,
+    editable: false,
     expandable: false,
   },
   [PropType.Null]: {


### PR DESCRIPTION
_Problem:_
As mentioned in #880, when the property type is date, the devtools just shows `Date()` instaed of showing the Date value as well.

I believe this is good enough for an MVP, just to show the date. (i would live to update the tests for this, but i believe there is none for this)

I believe we could further improve the UX and DX later on, by:
- Updating the demo app, so there would be a page, with all kinds of inputs, to test it out while developing the devtools
- Instead of just showing the property in an editable, it would be nice if a little icon would show up telling us it is indeed a Date type property. Just looking at the current solution, one might think it's a simple string ([like in the vue devtools](https://github.com/vuejs/devtools/raw/main/media/screenshot-shadow.png))
- I feel like devtool panel components should be refactord to be OnPush components. It's clear, that it has Inputs/Outputs, so tweaking it a little so changes are always immutable we could improve perf

Let me know what you think. I might create an issue for these, so we can improve this project in small steps.